### PR TITLE
Add more fields to StateMessage

### DIFF
--- a/cpp/include/network_interfaces/control_type.h
+++ b/cpp/include/network_interfaces/control_type.h
@@ -11,4 +11,29 @@ namespace network_interfaces {
 enum class control_type_t : std::uint8_t {
   UNDEFINED = 0, POSITION = 1, VELOCITY = 2, ACCELERATION = 3, EFFORT = 4,
 };
+
+std::ostream& operator<<(std::ostream& os, control_type_t control_type) {
+  switch (control_type) {
+    case control_type_t::UNDEFINED:
+      os << "UNDEFINED";
+      break;
+    case control_type_t::POSITION:
+      os << "POSITION";
+      break;
+    case control_type_t::VELOCITY:
+      os << "VELOCITY";
+      break;
+    case control_type_t::ACCELERATION:
+      os << "ACCELERATION";
+      break;
+    case control_type_t::EFFORT:
+      os << "EFFORT";
+      break;
+    default:
+      os << "UNKNOWN CONTROL TYPE";
+      break;
+  }
+  return os;
+}
+
 }// namespace network_interfaces

--- a/cpp/include/network_interfaces/control_type.h
+++ b/cpp/include/network_interfaces/control_type.h
@@ -9,7 +9,7 @@ namespace network_interfaces {
  * @brief An enumeration of the possible control types.
  */
 enum class control_type_t : std::uint8_t {
-  UNDEFINED = 0, POSITION = 1, VELOCITY = 2, ACCELERATION = 3, EFFORT = 4,
+  UNDEFINED = 0, POSITION = 1, VELOCITY = 2, ACCELERATION = 3, EFFORT = 4, END = 5,
 };
 
 std::ostream& operator<<(std::ostream& os, control_type_t control_type) {

--- a/cpp/include/network_interfaces/zmq/network.h
+++ b/cpp/include/network_interfaces/zmq/network.h
@@ -90,7 +90,8 @@ inline std::vector<std::string> encode_command(CommandMessage& command) {
     }
   }
   for (std::size_t i = 0; i < command.joint_state.get_size(); ++i) {
-    if (command.control_type.at(i) < 0 || command.control_type.at(i) > 4) {
+    if (static_cast<network_interfaces::control_type_t>(command.control_type.at(i))
+        >= network_interfaces::control_type_t::END) {
       throw network_interfaces::zmq::exceptions::UnknownControlTypeException(
           "The desired 'control_type' of the CommandMessage is unknown."
       );

--- a/cpp/test/test_communication.cpp
+++ b/cpp/test/test_communication.cpp
@@ -2,13 +2,18 @@
 #include <thread>
 
 #include "network_interfaces/zmq/network.h"
+#include "network_interfaces/zmq/exceptions/InvalidControlTypeVectorException.h"
+#include "network_interfaces/zmq/exceptions/UnknownControlTypeException.h"
 
-static void expect_joint_state_equal(const state_representation::JointState& js1, const state_representation::JointState& js2) {
+static void
+expect_joint_state_equal(const state_representation::JointState& js1, const state_representation::JointState& js2) {
   EXPECT_TRUE(js1.data().isApprox(js2.data()));
   EXPECT_TRUE(js1.is_compatible(js2));
 }
 
-static void expect_cart_state_equal(const state_representation::CartesianState& cs1, const state_representation::CartesianState& cs2) {
+static void expect_cart_state_equal(
+    const state_representation::CartesianState& cs1, const state_representation::CartesianState& cs2
+) {
   EXPECT_TRUE(cs1.data().isApprox(cs2.data()));
   EXPECT_TRUE(cs1.is_compatible(cs2));
 }
@@ -27,7 +32,8 @@ public:
   state_representation::CartesianState robot_state;
   state_representation::JointState robot_joint_state;
   state_representation::Jacobian robot_jacobian;
-  state_representation::Parameter<Eigen::MatrixXd> robot_mass = state_representation::Parameter<Eigen::MatrixXd>("robot");
+  state_representation::Parameter<Eigen::MatrixXd>
+      robot_mass = state_representation::Parameter<Eigen::MatrixXd>("robot");
   state_representation::JointState control_joint_state;
   std::vector<int> control_type;
 
@@ -88,6 +94,38 @@ public:
   }
 };
 
+TEST_F(TestNetworkInterface, TestEncodeCommand) {
+  network_interfaces::zmq::CommandMessage command;
+  command.joint_state = state_representation::JointState::Random("test", 3);
+  command.control_type = std::vector<int>{};
+  EXPECT_THROW(network_interfaces::zmq::encode_command(command),
+               network_interfaces::zmq::exceptions::InvalidControlTypeVectorException);
+
+  command.control_type = std::vector<int>{1};
+  network_interfaces::zmq::encode_command(command);
+  ASSERT_EQ(command.control_type.size(), 3);
+  for (std::size_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(command.control_type.at(i), 1);
+  }
+
+  command.control_type = std::vector<int>{1, 2, 6};
+  EXPECT_THROW(network_interfaces::zmq::encode_command(command),
+               network_interfaces::zmq::exceptions::UnknownControlTypeException);
+
+  command.control_type = std::vector<int>{1, 2, 2, 1};
+  EXPECT_THROW(network_interfaces::zmq::encode_command(command),
+               network_interfaces::zmq::exceptions::InvalidControlTypeVectorException);
+}
+
+TEST_F(TestNetworkInterface, TestEmptyEncodeCommand) {
+  network_interfaces::zmq::CommandMessage command;
+  EXPECT_NO_THROW(network_interfaces::zmq::encode_command(command));
+
+  command.control_type = std::vector<int>{1};
+  EXPECT_THROW(network_interfaces::zmq::encode_command(command),
+               network_interfaces::zmq::exceptions::InvalidControlTypeVectorException);
+}
+
 TEST_F(TestNetworkInterface, TestCommunication) {
   std::thread robot = spawn_robot();
   std::thread control = spawn_control();
@@ -96,7 +134,7 @@ TEST_F(TestNetworkInterface, TestCommunication) {
   control.join();
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/python/network_interfaces/control_type.py
+++ b/python/network_interfaces/control_type.py
@@ -10,3 +10,4 @@ class ControlType(Enum):
     VELOCITY = 2
     ACCELERATION = 3
     EFFORT = 4
+    END = 5

--- a/python/network_interfaces/tests/test_communication.py
+++ b/python/network_interfaces/tests/test_communication.py
@@ -2,15 +2,19 @@ import threading
 import time
 import unittest
 
-from network_interfaces.zmq import network
+import numpy as np
 import state_representation as sr
 import zmq
 from numpy.testing import assert_array_almost_equal
+
+from network_interfaces.zmq import network
 
 
 class TestNetworkInterface(unittest.TestCase):
     robot_state = None
     robot_joint_state = None
+    robot_jacobian = None
+    robot_mass = None
     control_command = None
     control_type = None
     context = None
@@ -21,15 +25,21 @@ class TestNetworkInterface(unittest.TestCase):
     def setUpClass(cls):
         cls.robot_state = sr.CartesianState().Random("ee", "robot")
         cls.robot_joint_state = sr.JointState().Random("robot", 3)
+        cls.robot_jacobian = sr.Jacobian().Random("robot", 3, "frame")
+        cls.robot_mass = sr.Parameter("mass", np.random.rand(3, 3), sr.StateType.PARAMETER_MATRIX)
         cls.control_command = sr.JointState().Random("robot", 3)
         cls.control_type = [1, 2, 3]
         cls.context = zmq.Context()
+
+    def assert_state_equal(self, state1, state2):
+        self.assertTrue(state1.is_compatible(state2))
+        assert_array_almost_equal(state1.data(), state2.data())
 
     def robot(self):
         command_subscriber, state_publisher = network.configure_sockets(self.context, "127.0.0.1:1702",
                                                                         "127.0.0.1:1701")
 
-        state = network.StateMessage(self.robot_state, self.robot_joint_state)
+        state = network.StateMessage(self.robot_state, self.robot_joint_state, self.robot_jacobian, self.robot_mass)
         command = []
         for i in range(100):
             network.send_state(state, state_publisher)
@@ -59,10 +69,10 @@ class TestNetworkInterface(unittest.TestCase):
 
         [self.assertEqual(self.received_command.control_type[i], self.control_type[i]) for i in
          range(len(self.control_type))]
-        self.assertTrue(self.received_command.joint_state.is_compatible(self.control_command))
-        assert_array_almost_equal(self.received_command.joint_state.data(), self.control_command.data())
+        self.assert_state_equal(self.received_command.joint_state, self.control_command)
 
-        self.assertTrue(self.received_state.ee_state.is_compatible(self.robot_state))
-        assert_array_almost_equal(self.received_state.ee_state.data(), self.robot_state.data())
-        self.assertTrue(self.received_state.joint_state.is_compatible(self.robot_joint_state))
-        assert_array_almost_equal(self.received_state.joint_state.data(), self.robot_joint_state.data())
+        self.assert_state_equal(self.received_state.ee_state, self.robot_state)
+        self.assert_state_equal(self.received_state.joint_state, self.robot_joint_state)
+        self.assert_state_equal(self.received_state.jacobian, self.robot_jacobian)
+        self.assertTrue(self.received_state.mass.is_compatible(self.robot_mass))
+        assert_array_almost_equal(self.received_state.mass.get_value(), self.robot_mass.get_value())

--- a/python/network_interfaces/tests/test_communication.py
+++ b/python/network_interfaces/tests/test_communication.py
@@ -76,3 +76,25 @@ class TestNetworkInterface(unittest.TestCase):
         self.assert_state_equal(self.received_state.jacobian, self.robot_jacobian)
         self.assertTrue(self.received_state.mass.is_compatible(self.robot_mass))
         assert_array_almost_equal(self.received_state.mass.get_value(), self.robot_mass.get_value())
+
+    def test_encode_command(self):
+        command = network.CommandMessage([], sr.JointState())
+        network.encode_command(command)
+
+        command = network.CommandMessage([], sr.JointState().Random("test", 3))
+        with self.assertRaises(ValueError):
+            network.encode_command(command)
+
+        command.control_type = [1]
+        encoded = network.encode_command(command)
+        decoded = network.decode_command(encoded)
+        self.assertEqual(len(decoded.control_type), 3)
+        assert_array_almost_equal(decoded.control_type, [1, 1, 1])
+
+        command.control_type = [1, 2, 6]
+        with self.assertRaises(ValueError):
+            network.encode_command(command)
+
+        command.control_type = [1, 2, 2, 1]
+        with self.assertRaises(ValueError):
+            network.encode_command(command)

--- a/python/network_interfaces/zmq/network.py
+++ b/python/network_interfaces/zmq/network.py
@@ -13,6 +13,8 @@ class StateMessage:
     """
     ee_state: sr.CartesianState
     joint_state: sr.JointState
+    jacobian: sr.Jacobian
+    mass: sr.Parameter("mass", sr.StateType.PARAMETER_MATRIX)
 
 
 @dataclass
@@ -37,6 +39,8 @@ def encode_state(state):
     encoded_state = list()
     encoded_state.append(clproto.encode(state.ee_state, clproto.MessageType.CARTESIAN_STATE_MESSAGE))
     encoded_state.append(clproto.encode(state.joint_state, clproto.MessageType.JOINT_STATE_MESSAGE))
+    encoded_state.append(clproto.encode(state.jacobian, clproto.MessageType.JACOBIAN_MESSAGE))
+    encoded_state.append(clproto.encode(state.mass, clproto.MessageType.PARAMETER_MESSAGE))
     return encoded_state
 
 
@@ -65,7 +69,8 @@ def decode_state(message):
     :return: The equivalent StateMessage
     :rtype: StateMessage
     """
-    state = StateMessage(clproto.decode(message[0]), clproto.decode(message[1]))
+    state = StateMessage(clproto.decode(message[0]), clproto.decode(message[1]), clproto.decode(message[2]),
+                         clproto.decode(message[3]))
     return state
 
 

--- a/python/network_interfaces/zmq/network.py
+++ b/python/network_interfaces/zmq/network.py
@@ -5,6 +5,8 @@ import clproto
 import state_representation as sr
 import zmq
 
+from network_interfaces.control_type import ControlType
+
 
 @dataclass
 class StateMessage:
@@ -79,7 +81,7 @@ def encode_command(command):
             raise ValueError("The size of field 'control_type' of the CommandMessage does not correspond"
                              " to the size of the field 'joint state'.")
     for i in range(command.joint_state.get_size()):
-        if command.control_type[i] < 0 or command.control_type[i] > 4:
+        if command.control_type[i] >= ControlType.END.value:
             raise ValueError("The desired 'control_type' of the CommandMessage is unknown.")
     encoded_command = list()
     control_type_param = sr.Parameter("control_type", command.control_type, sr.StateType.PARAMETER_INT_ARRAY)


### PR DESCRIPTION
I added ostream operators for the messages in cpp and init functions in Python to assert the types are correct.
More importantly, I added jacobian and mass matrix to the StateMessage and added some logic in encode_command that the control_type is correct.
@eeberhard 