### PR TITLE
Change to build-server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,7 @@ of the binding sockets. For example, if the containers are running on network *a
 Build and run a Docker container as an SSH toolchain server for remote development with:
 
 ```console
-bash build.sh
-aica-docker server aica-technology/network-interfaces:core-dependencies -u ros2 -p 8010
+bash build-server.sh -s
 ```
 
 Note: This requires the installation of the `aica-docker` scripts

--- a/build-server.sh
+++ b/build-server.sh
@@ -7,9 +7,7 @@ IMAGE_STAGE=core-dependencies
 SERVE_REMOTE=false
 REMOTE_SSH_PORT=4420
 
-BUILD_FLAGS=()
-
-HELP_MESSAGE="Usage: ./build.sh [-t] [-r] [-v] [-s]
+HELP_MESSAGE="Usage: ./build-server.sh [-t] [-r] [-v] [-s]
 
 Build a Docker container for remote development and/or running unittests.
 
@@ -26,6 +24,7 @@ Options:
   -h, --help               Show this help message.
 "
 
+BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -t|--test) IMAGE_STAGE=build-test; shift 1;;

--- a/build-server.sh
+++ b/build-server.sh
@@ -4,27 +4,34 @@ ROS_VERSION=foxy
 IMAGE_NAME=aica-technology/network-interfaces
 IMAGE_STAGE=core-dependencies
 
+SERVE_REMOTE=false
+REMOTE_SSH_PORT=4420
+
 BUILD_FLAGS=()
 
-HELP_MESSAGE="Usage: ./build.sh [--rebuild] [--test] [--verbose]
+HELP_MESSAGE="Usage: ./build.sh [-t] [-r] [-v] [-s]
 
 Build a Docker container for remote development and/or running unittests.
 
 Options:
-  -r, --rebuild            Rebuild the image with no cache.
-
   -t, --test               Build and run all the unittests.
+
+  -r, --rebuild            Rebuild the image with no cache.
 
   -v, --verbose            Show all the output of the Docker
                            build process
 
-  -h, --help               Show this help message."
+  -s, --serve              Start the remove development server.
+
+  -h, --help               Show this help message.
+"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    -r|--rebuild) BUILD_FLAGS+=(--no-cache); shift 1;;
     -t|--test) IMAGE_STAGE=build-test; shift 1;;
+    -r|--rebuild) BUILD_FLAGS+=(--no-cache); shift 1;;
     -v|--verbose) BUILD_FLAGS+=(--progress=plain); shift 1;;
+    -s|--serve) SERVE_REMOTE=true ; shift ;;
     -h|--help) echo "${HELP_MESSAGE}"; exit 0;;
     *) echo "Unknown option: $1" >&2; echo "${HELP_MESSAGE}"; exit 1;;
   esac
@@ -36,3 +43,7 @@ BUILD_FLAGS+=(--target "${IMAGE_STAGE}")
 
 docker pull ghcr.io/aica-technology/ros2-control-libraries:"${ROS_VERSION}"
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .
+
+if [ "${SERVE_REMOTE}" = true ]; then
+  aica-docker server "${IMAGE_NAME}:${IMAGE_STAGE}" -u ros2 -p "${REMOTE_SSH_PORT}"
+fi


### PR DESCRIPTION
I was using this repo to do some tests for the simulation and I quite like the `build-server` scripts we started using because it fixes the ssh port number.