### PR TITLE
Add CMake package configuration

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -23,14 +23,21 @@ else()
     find_package(GTest QUIET)
 endif()
 
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
 find_package(control_libraries 6.0.0 REQUIRED COMPONENTS state_representation)
 find_package(clproto 6.0.0 REQUIRED)
-find_package(cppzmq REQUIRED)
+find_package(cppzmq 4.7.1 REQUIRED)
 
 include_directories(include)
 
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE include)
+target_link_libraries(${PROJECT_NAME} INTERFACE clproto cppzmq state_representation)
+
 install(DIRECTORY include/
-        DESTINATION include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 add_executable(zmq_loopback_state scripts/zmq_loopback_state.cpp)
@@ -44,3 +51,23 @@ if(BUILD_TESTING)
     target_link_libraries(test_zmq_communication ${GTEST_LIBRARIES} pthread clproto cppzmq state_representation)
     add_test(NAME test_zmq_communication COMMAND test_zmq_communication)
 endif()
+
+# generate the version file for the config file
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  VERSION "${PROJECT_VERSION}"
+  COMPATIBILITY SameMajorVersion
+)
+
+# create config file
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+
+# install config files
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)

--- a/cpp/Config.cmake.in
+++ b/cpp/Config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+set(network_interfaces_LIBRARIES cppzmq clproto state_representation)
+
+include(CMakeFindDependencyMacro)
+find_dependency(cppzmq)


### PR DESCRIPTION
Sorry guys, something I forgot I had prepared before the release is this CMake configuration. It creates a header only library that already links `cppzmq` for users. This means that for example in the franka lwi, we will be able to do
```
find_package(Franka 0.8.0 REQUIRED)
find_package(network_interfaces 1.0.0 REQUIRED)
...
target_link_libraries(${PROJECT_NAME} franka ${network_interfaces_LIBRARIES})
```
instead of
```
find_package(cppzmq REQUIRED)
find_package(Eigen3 REQUIRED)
find_package(Franka 0.8.0 REQUIRED)
find_library(clproto REQUIRED)
find_library(network_interfaces REQUIRED)
find_library(state_representation REQUIRED)
...
target_link_libraries(${PROJECT_NAME} franka clproto cppzmq state_representation)
```

Would be nice if this goes in before #16 
