### PR TITLE
Make Python tests pass more reliably with Executor

### DIFF
--- a/python/test/test_zmq_communication.py
+++ b/python/test/test_zmq_communication.py
@@ -1,6 +1,6 @@
+import concurrent.futures
 import numpy as np
 import state_representation as sr
-import threading
 import time
 import unittest
 import zmq
@@ -39,7 +39,8 @@ class TestZMQNetworkInterface(unittest.TestCase):
 
         state = network.StateMessage(self.robot_state, self.robot_joint_state, self.robot_jacobian, self.robot_mass)
         command = []
-        for i in range(200):
+        start_time = time.time()
+        while time.time() - start_time < 2.:
             network.send_state(state, state_publisher)
             command = network.receive_command(command_subscriber)
             time.sleep(0.01)
@@ -53,7 +54,8 @@ class TestZMQNetworkInterface(unittest.TestCase):
 
         command = network.CommandMessage(self.control_type, self.control_command)
         state = []
-        for i in range(200):
+        start_time = time.time()
+        while time.time() - start_time < 2.:
             network.send_command(command, command_publisher)
             state = network.receive_state(state_subscriber)
             time.sleep(0.01)
@@ -62,12 +64,9 @@ class TestZMQNetworkInterface(unittest.TestCase):
         self.received_state = state
 
     def test_communication(self):
-        robot = threading.Thread(target=self.robot)
-        control = threading.Thread(target=self.control)
-        robot.start()
-        control.start()
-        robot.join()
-        control.join()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as e:
+            e.submit(self.robot)
+            e.submit(self.control)
 
         [self.assertEqual(self.received_command.control_type[i], self.control_type[i]) for i in
          range(len(self.control_type))]


### PR DESCRIPTION
Something that was bugging me for a long time was that the tests here in the network interfaces only pass like 1 out of 4 times or worse so I wanted to fix that. While I was doing that I learned that two python threads don't run in parallel which is why the tests were not really able to communicate between each other because they only ran one after another. So now I'm using a ThreadPoolExecutor that actually runs both threads at the same time (concurrently) and now the tests pass all the time