### PR TITLE
Add ZMQ publisher and subscriber classes

### DIFF
--- a/source/communication_interfaces/CMakeLists.txt
+++ b/source/communication_interfaces/CMakeLists.txt
@@ -36,6 +36,9 @@ add_library(${PROJECT_NAME} SHARED
         ${PROJECT_SOURCE_DIR}/src/sockets/UDPSocket.cpp
         ${PROJECT_SOURCE_DIR}/src/sockets/UDPClient.cpp
         ${PROJECT_SOURCE_DIR}/src/sockets/UDPServer.cpp
+        ${PROJECT_SOURCE_DIR}/src/sockets/ZMQSocket.cpp
+        ${PROJECT_SOURCE_DIR}/src/sockets/ZMQPublisher.cpp
+        ${PROJECT_SOURCE_DIR}/src/sockets/ZMQSubscriber.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 target_link_libraries(${PROJECT_NAME} PUBLIC cppzmq state_representation)

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisher.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisher.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "communication_interfaces/sockets/ZMQSocket.hpp"
+
+namespace communication_interfaces::sockets {
+
+class ZMQPublisher : public ZMQSocket {
+public:
+  explicit ZMQPublisher(const std::shared_ptr<zmq::context_t>& context);
+
+  explicit ZMQPublisher(
+      const state_representation::ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context
+  );
+
+  void open() override;
+
+  bool receive_bytes(ByteArray& buffer) override;
+};
+} // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisher.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisher.hpp
@@ -4,16 +4,31 @@
 
 namespace communication_interfaces::sockets {
 
+/**
+ * @brief Class to define a ZMQ publisher
+ */
 class ZMQPublisher : public ZMQSocket {
 public:
+  /**
+   * @copydoc ZMQSocket::ZMQSocket(const std::shared_ptr<zmq::context_t>&)
+   */
   explicit ZMQPublisher(const std::shared_ptr<zmq::context_t>& context);
 
+  /**
+   * @copydoc ZMQSocket::ZMQSocket(const state_representation::ParameterInterfaceList&, const std::shared_ptr<zmq::context_t>&)
+   */
   explicit ZMQPublisher(
       const state_representation::ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context
   );
 
+  /**
+   * @copydoc ISocket::open()
+   */
   void open() override;
 
+  /**
+   * @brief This method throws a runtime error as receiving is not available for a ZMQ publisher
+   */
   bool receive_bytes(ByteArray& buffer) override;
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSocket.hpp
@@ -6,27 +6,56 @@
 
 namespace communication_interfaces::sockets {
 
+/**
+ * @brief Abstract class to define a generic ZMQ socket
+ */
 class ZMQSocket : public ISocket {
 public:
+  /**
+   * @brief Close the socket by calling ZMQSocket::close()
+   */
   ~ZMQSocket() override;
 
+  /**
+   * @brief Close the socket
+   */
   void close() override;
 
+  /**
+   * @copydoc ISocket::receive_bytes(ByteArray&)
+   */
   bool receive_bytes(ByteArray& buffer) override;
 
+  /**
+   * @copydoc ISocket::send_bytes(ByteArray&)
+   */
   bool send_bytes(const ByteArray& buffer) override;
 
 protected:
+   /**
+    * @brief Add the parameters with no or default value to the map
+    * @param context The ZMQ context to be used for the sockets
+    * (it's recommended to only use one context per application)
+    */
   explicit ZMQSocket(const std::shared_ptr<zmq::context_t>& context);
 
+  /**
+   * @brief Add and set the parameters with the parameters given as argument
+   * @param parameters The list of parameters
+   * @param context The ZMQ context to be used for the sockets
+    * (it's recommended to only use one context per application)
+   */
   ZMQSocket(
       const state_representation::ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context
   );
 
+  /**
+   * @brief Bind or connect the socket on the desired IP/port
+   */
   void open_socket();
 
-  std::shared_ptr<zmq::context_t> context_;
-  std::shared_ptr<zmq::socket_t> socket_;
+  std::shared_ptr<zmq::context_t> context_; ///< ZMQ context
+  std::shared_ptr<zmq::socket_t> socket_; ///< ZMQ socket
 
 private:
   /**
@@ -35,6 +64,6 @@ private:
    */
   void validate_and_set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) final;
 
-  std::shared_ptr<state_representation::Parameter<bool>> wait_;
+  std::shared_ptr<state_representation::Parameter<bool>> wait_; ///< If false, send and receive are blocking
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSocket.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <zmq.hpp>
+
+#include "communication_interfaces/sockets/ISocket.hpp"
+
+namespace communication_interfaces::sockets {
+
+class ZMQSocket : public ISocket {
+public:
+  ~ZMQSocket() override;
+
+  void close() override;
+
+  bool receive_bytes(ByteArray& buffer) override;
+
+  bool send_bytes(const ByteArray& buffer) override;
+
+protected:
+  explicit ZMQSocket(const std::shared_ptr<zmq::context_t>& context);
+
+  ZMQSocket(
+      const state_representation::ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context
+  );
+
+  void open_socket();
+
+  std::shared_ptr<zmq::context_t> context_;
+  std::shared_ptr<zmq::socket_t> socket_;
+
+private:
+  /**
+   * @brief Validate and set parameters
+   * @param parameter A parameter interface pointer
+   */
+  void validate_and_set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) final;
+
+  std::shared_ptr<state_representation::Parameter<bool>> wait_;
+};
+} // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSubscriber.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSubscriber.hpp
@@ -4,16 +4,31 @@
 
 namespace communication_interfaces::sockets {
 
+/**
+ * @brief Class to define a ZMQ subscriber
+ */
 class ZMQSubscriber : public ZMQSocket {
 public:
+  /**
+   * @copydoc ZMQSocket::ZMQSocket(const std::shared_ptr<zmq::context_t>&)
+   */
   explicit ZMQSubscriber(const std::shared_ptr<zmq::context_t>& context);
 
+  /**
+   * @copydoc ZMQSocket::ZMQSocket(const state_representation::ParameterInterfaceList&, const std::shared_ptr<zmq::context_t>&)
+   */
   explicit ZMQSubscriber(
       const state_representation::ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context
   );
 
+  /**
+   * @copydoc ISocket::open()
+   */
   void open() override;
 
+  /**
+   * @brief This method throws a runtime error as sending is not available for a ZMQ publisher
+   */
   bool send_bytes(const ByteArray& buffer) override;
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSubscriber.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSubscriber.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "communication_interfaces/sockets/ZMQSocket.hpp"
+
+namespace communication_interfaces::sockets {
+
+class ZMQSubscriber : public ZMQSocket {
+public:
+  explicit ZMQSubscriber(const std::shared_ptr<zmq::context_t>& context);
+
+  explicit ZMQSubscriber(
+      const state_representation::ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context
+  );
+
+  void open() override;
+
+  bool send_bytes(const ByteArray& buffer) override;
+};
+} // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/src/sockets/ZMQPublisher.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQPublisher.cpp
@@ -1,0 +1,20 @@
+#include "communication_interfaces/sockets/ZMQPublisher.hpp"
+
+namespace communication_interfaces::sockets {
+
+using namespace state_representation;
+
+ZMQPublisher::ZMQPublisher(const std::shared_ptr<zmq::context_t>& context) : ZMQSocket(context) {}
+
+ZMQPublisher::ZMQPublisher(const ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context) :
+    ZMQSocket(parameters, context) {}
+
+void ZMQPublisher::open() {
+  this->socket_ = std::make_shared<zmq::socket_t>(*this->context_, ZMQ_PUB);
+  this->open_socket();
+}
+
+bool ZMQPublisher::receive_bytes(ByteArray&) {
+  throw std::runtime_error("Receive not available for socket of type ZMQPublisher");
+}
+} // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/src/sockets/ZMQSocket.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQSocket.cpp
@@ -1,0 +1,86 @@
+#include "communication_interfaces/sockets/ZMQSocket.hpp"
+
+#include "communication_interfaces/exceptions/SocketConfigurationException.hpp"
+
+namespace communication_interfaces::sockets {
+
+using namespace state_representation;
+
+ZMQSocket::ZMQSocket(const std::shared_ptr<zmq::context_t>& context) :
+    context_(context), wait_(std::make_shared<Parameter<bool>>("wait", false)) {
+  this->parameters_.insert_or_assign("ip_address", std::make_shared<Parameter<std::string>>("ip_address"));
+  this->parameters_.insert_or_assign("port", std::make_shared<Parameter<int>>("port"));
+  this->parameters_.insert_or_assign("bind_socket", std::make_shared<Parameter<bool>>("bind_socket"));
+  this->parameters_.insert(std::make_pair("wait", this->wait_));
+}
+
+ZMQSocket::ZMQSocket(const ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context) :
+    ZMQSocket(context) {
+  this->set_parameters(parameters);
+}
+
+ZMQSocket::~ZMQSocket() {
+  ZMQSocket::close();
+}
+
+void ZMQSocket::open_socket() {
+  try {
+    auto address = "tcp://" + this->get_parameter_value<std::string>("ip_address") + ":"
+        + this->get_parameter_value<std::string>("port");
+    if (this->get_parameter_value<bool>("bind_socket")) {
+      this->socket_->bind(address);
+    } else {
+      this->socket_->connect(address);
+    }
+  } catch (const std::exception& ex) {
+    throw exceptions::SocketConfigurationException("Socket configuration failed: " + std::string(ex.what()));
+  }
+}
+
+bool ZMQSocket::receive_bytes(ByteArray& buffer) {
+  zmq::recv_flags recv_flag = this->wait_->get_value() ? zmq::recv_flags::none : zmq::recv_flags::dontwait;
+  zmq::message_t message;
+  try {
+    auto received = this->socket_->recv(message, recv_flag);
+    if (received.has_value()) {
+      buffer.reset();
+      buffer.load(message.data(), message.size());
+    }
+    return received.has_value();
+  } catch (const zmq::error_t&) {
+    return false;
+  }
+}
+
+bool ZMQSocket::send_bytes(const ByteArray& buffer) {
+  zmq::send_flags send_flags = this->wait_->get_value() ? zmq::send_flags::none : zmq::send_flags::dontwait;
+  std::vector<char> local_buffer;
+  buffer.copy_to(local_buffer);
+  zmq::message_t msg(local_buffer.begin(), local_buffer.end());
+  try {
+    auto sent = this->socket_->send(msg, send_flags);
+    return sent.has_value();
+  } catch (const zmq::error_t&) {
+    return false;
+  }
+}
+
+void ZMQSocket::validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) {
+  this->assert_parameter_valid(parameter);
+  if (parameter->is_empty()) {
+    throw state_representation::exceptions::InvalidParameterException(
+        "Parameter '" + parameter->get_name() + "' cannot be empty.");
+  }
+  if (parameter->get_name() == "wait") {
+    this->parameters_.at(parameter->get_name())->set_parameter_value(parameter->get_parameter_value<bool>());
+  } else {
+    this->parameters_.insert_or_assign(parameter->get_name(), parameter);
+  }
+}
+
+void ZMQSocket::close() {
+  if (this->socket_ != nullptr && this->socket_->connected()) {
+    this->socket_->close();
+  }
+}
+} // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/src/sockets/ZMQSubscriber.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQSubscriber.cpp
@@ -1,0 +1,22 @@
+#include "communication_interfaces/sockets/ZMQSubscriber.hpp"
+
+namespace communication_interfaces::sockets {
+
+using namespace state_representation;
+
+ZMQSubscriber::ZMQSubscriber(const std::shared_ptr<zmq::context_t>& context) : ZMQSocket(context) {}
+
+ZMQSubscriber::ZMQSubscriber(const ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context) :
+    ZMQSocket(parameters, context) {}
+
+void ZMQSubscriber::open() {
+  this->socket_ = std::make_shared<zmq::socket_t>(*this->context_, ZMQ_SUB);
+  this->open_socket();
+  this->socket_->set(zmq::sockopt::conflate, 1);
+  this->socket_->set(zmq::sockopt::subscribe, "");
+}
+
+bool ZMQSubscriber::send_bytes(const ByteArray&) {
+  throw std::runtime_error("Send not available for socket of type ZMQSubscriber");
+}
+} // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/test/tests/test_zmq_communication.cpp
+++ b/source/communication_interfaces/test/tests/test_zmq_communication.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "communication_interfaces/sockets/ZMQPublisher.hpp"
+#include "communication_interfaces/sockets/ZMQSubscriber.hpp"
+
+using namespace communication_interfaces;
+using namespace std::chrono_literals;
+
+class TestZMQSockets : public ::testing::Test {
+public:
+  TestZMQSockets() {
+      params_.emplace_back(state_representation::make_shared_parameter<std::string>("ip_address", "127.0.0.1"));
+      params_.emplace_back(state_representation::make_shared_parameter<std::string>("port", "5000"));
+      context_ = std::make_shared<zmq::context_t>(1);
+    }
+
+    std::shared_ptr<zmq::context_t> context_;
+    state_representation::ParameterInterfaceList params_;
+};
+
+TEST_F(TestZMQSockets, SendReceive) {
+  const std::string send_string = "Hello world!";
+
+  this->params_.emplace_back(state_representation::make_shared_parameter<bool>("bind_socket", true));
+  sockets::ZMQPublisher publisher(this->params_, this->context_);
+
+  this->params_.pop_back();
+  this->params_.emplace_back(state_representation::make_shared_parameter<bool>("bind_socket", false));
+  sockets::ZMQSubscriber subscriber(this->params_, this->context_);
+
+  publisher.open();
+  subscriber.open();
+
+  ByteArray message;
+  message.copy_from(send_string);
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_TRUE(publisher.send_bytes(message));
+    usleep(10000);
+  }
+  message.reset();
+  ASSERT_TRUE(subscriber.receive_bytes(message));
+  std::string received_string;
+  message.copy_to(received_string);
+  EXPECT_STREQ(received_string.c_str(), send_string.c_str());
+  publisher.close();
+  subscriber.close();
+}


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- #28

<!-- Required: explain how the PR addresses the parent issue -->
As with the UDP sockets, a fairly big PR due to the docstrings and header files.
There is a pattern here that is maybe not optimal, namely that `ZMQSubscriber::send_bytes` and `ZMQPublisher::receive_bytes` both throw a runtime error because this action is not available for the respective sockets. Do you think this makes sense or should we rather pack two sockets into one class and have a ZMQ server (sub and pub socket - binding) and a ZMQ client (sub and pub socket - non binding)?

This has also been tested with the pybullet simulation and works well :+1:

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 20 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->