### PR TITLE
Remove state representation dependencies

### DIFF
--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -12,10 +12,4 @@ RUN tar -xzf cppzmq-${CPPZMQ_VERSION}.tar.gz
 WORKDIR /tmp/cppzmq-${CPPZMQ_VERSION}
 RUN mkdir build && cd build && cmake .. -DCPPZMQ_BUILD_TESTS=OFF && make -j install
 
-
-WORKDIR /tmp
-ARG CONTROL_LIBRARIES_BRANCH=v7.0.0
-RUN git clone -b ${CONTROL_LIBRARIES_BRANCH} --depth 1 https://github.com/aica-technology/control-libraries.git
-RUN cd control-libraries/source && ./install.sh --auto --no-controllers --no-dynamical-systems --no-robot-model
-
 RUN rm -rf /tmp/*

--- a/source/communication_interfaces/CMakeLists.txt
+++ b/source/communication_interfaces/CMakeLists.txt
@@ -38,8 +38,6 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(FindPkgConfig)
 
-add_project_dependency(control_libraries 7.0.0 REQUIRED COMPONENTS state_representation)
-add_project_dependency(clproto 7.0.0 REQUIRED)
 add_project_dependency(cppzmq 4.7.1 REQUIRED)
 
 include_directories(include)
@@ -54,7 +52,7 @@ add_library(${PROJECT_NAME} SHARED
         ${PROJECT_SOURCE_DIR}/src/sockets/ZMQSubscriber.cpp
 )
 target_include_directories(${PROJECT_NAME} PUBLIC include)
-target_link_libraries(${PROJECT_NAME} PUBLIC cppzmq state_representation)
+target_link_libraries(${PROJECT_NAME} PUBLIC cppzmq)
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/source/communication_interfaces/communication_interfaces-config.cmake.in
+++ b/source/communication_interfaces/communication_interfaces-config.cmake.in
@@ -1,6 +1,4 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(state_representation)
-find_dependency(clproto)
 find_dependency(cppzmq)

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ISocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ISocket.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <state_representation/parameters/ParameterMap.hpp>
-
 #include "communication_interfaces/ByteArray.hpp"
 
 namespace communication_interfaces::sockets {
@@ -9,7 +7,7 @@ namespace communication_interfaces::sockets {
 /**
  * @brief Interface class to define functions required for simple socket communication
  */
-class ISocket : public state_representation::ParameterMap {
+class ISocket {
 public:
   /**
    * @brief Default constructor

--- a/source/communication_interfaces/include/communication_interfaces/sockets/UDPClient.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/UDPClient.hpp
@@ -5,19 +5,15 @@
 namespace communication_interfaces::sockets {
 
 /**
+ * @class UDPClient
  * @brief Class to define a UDP client
  */
 class UDPClient : public UDPSocket {
 public:
   /**
-   * @copydoc UDPSocket::UDPSocket()
+   * @copydoc UDPSocket::UDPSocket(UDPSocketConfiguration)
    */
-  UDPClient();
-
-  /**
-   * @copydoc UDPSocket::UDPSocket(const state_representation::ParameterInterfaceList&)
-   */
-  explicit UDPClient(const state_representation::ParameterInterfaceList& parameters);
+  UDPClient(UDPSocketConfiguration configuration);
 
   /**
    * @copydoc ISocket::open()

--- a/source/communication_interfaces/include/communication_interfaces/sockets/UDPServer.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/UDPServer.hpp
@@ -5,19 +5,15 @@
 namespace communication_interfaces::sockets {
 
 /**
+ * @class UDPServer
  * @brief Class to define a UDP server
  */
 class UDPServer : public UDPSocket {
 public:
   /**
-   * @copydoc UDPSocket::UDPSocket()
+   * @copydoc UDPSocket::UDPSocket(UDPSocketConfiguration)
    */
-  UDPServer();
-
-  /**
-   * @copydoc UDPSocket::UDPSocket(const state_representation::ParameterInterfaceList&)
-   */
-  explicit UDPServer(const std::list<std::shared_ptr<state_representation::ParameterInterface>>& parameters);
+  UDPServer(UDPSocketConfiguration configuration);
 
   /**
    * @copydoc ISocket::open()

--- a/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
@@ -11,8 +11,6 @@ namespace communication_interfaces::sockets {
  * @brief Configuration parameters for a UDP sockets
  */
 struct UDPSocketConfiguration {
-  UDPSocketConfiguration() = delete;
-
   std::string ip_address;
   int port;
   int buffer_size;

--- a/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
@@ -7,6 +7,27 @@
 namespace communication_interfaces::sockets {
 
 /**
+ * @struct UDPSocketConfiguration
+ * @brief Configuration parameters for a UDP sockets
+ */
+struct UDPSocketConfiguration {
+  UDPSocketConfiguration(
+      std::string ip_address, int port, int buffer_size, bool enable_reuse = false, double timeout_duration_sec = 0.0
+  ) :
+      ip_address(std::move(ip_address)),
+      port(port),
+      buffer_size(buffer_size),
+      enable_reuse(enable_reuse),
+      timeout_duration_sec(timeout_duration_sec) {}
+  std::string ip_address;
+  int port;
+  int buffer_size;
+  bool enable_reuse;
+  double timeout_duration_sec;
+};
+
+/**
+ * @class UDPSocket
  * @brief Abstract class to define a generic UDP socket
  */
 class UDPSocket : public ISocket {
@@ -23,15 +44,10 @@ public:
 
 protected:
   /**
-   * @brief Add the parameters with no or default value to the map
+   * @brief Constructor taking the configuration struct
+   * @param The configuration struct
    */
-  UDPSocket();
-
-  /**
-   * @brief Add and set the parameters with the parameters given as argument
-   * @param parameters The list of parameters
-   */
-  explicit UDPSocket(const state_representation::ParameterInterfaceList& parameters);
+  explicit UDPSocket(UDPSocketConfiguration configuration);
 
   /**
    * @brief Perform steps to open the socket on the desired IP/port, set reuse and timeout options and bind if desired.
@@ -58,14 +74,7 @@ protected:
   sockaddr_in server_address_; ///< Address of the UDP server
 
 private:
-  /**
-   * @brief Validate and set parameters
-   * @param parameter A parameter interface pointer
-   */
-  void validate_and_set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override;
-
-  std::shared_ptr<state_representation::Parameter<int>> buffer_size_; ///< Maximal size of buffer to receive
-
+  UDPSocketConfiguration config_; ///< Socket configuration struct
   int server_fd_; ///< File descriptor of the socket
   socklen_t addr_len_; ///< Length of the socket address
 };

--- a/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
@@ -11,19 +11,13 @@ namespace communication_interfaces::sockets {
  * @brief Configuration parameters for a UDP sockets
  */
 struct UDPSocketConfiguration {
-  UDPSocketConfiguration(
-      std::string ip_address, int port, int buffer_size, bool enable_reuse = false, double timeout_duration_sec = 0.0
-  ) :
-      ip_address(std::move(ip_address)),
-      port(port),
-      buffer_size(buffer_size),
-      enable_reuse(enable_reuse),
-      timeout_duration_sec(timeout_duration_sec) {}
+  UDPSocketConfiguration() = delete;
+
   std::string ip_address;
   int port;
   int buffer_size;
-  bool enable_reuse;
-  double timeout_duration_sec;
+  bool enable_reuse = false;
+  double timeout_duration_sec = 0.0;
 };
 
 /**

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisher.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisher.hpp
@@ -5,21 +5,15 @@
 namespace communication_interfaces::sockets {
 
 /**
+ * @class ZMQPublisher
  * @brief Class to define a ZMQ publisher
  */
 class ZMQPublisher : public ZMQSocket {
 public:
   /**
-   * @copydoc ZMQSocket::ZMQSocket(const std::shared_ptr<zmq::context_t>&)
+   * @copydoc ZMQSocket::ZMQSocket(ZMQSocketConfiguration, const std::shared_ptr<zmq::context_t>&)
    */
-  explicit ZMQPublisher(const std::shared_ptr<zmq::context_t>& context);
-
-  /**
-   * @copydoc ZMQSocket::ZMQSocket(const state_representation::ParameterInterfaceList&, const std::shared_ptr<zmq::context_t>&)
-   */
-  explicit ZMQPublisher(
-      const state_representation::ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context
-  );
+  explicit ZMQPublisher(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context);
 
   /**
    * @copydoc ISocket::open()

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisher.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisher.hpp
@@ -11,9 +11,9 @@ namespace communication_interfaces::sockets {
 class ZMQPublisher : public ZMQSocket {
 public:
   /**
-   * @copydoc ZMQSocket::ZMQSocket(ZMQSocketConfiguration, const std::shared_ptr<zmq::context_t>&)
+   * @copydoc ZMQSocket::ZMQSocket(ZMQSocketConfiguration)
    */
-  explicit ZMQPublisher(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context);
+  explicit ZMQPublisher(ZMQSocketConfiguration configuration);
 
   /**
    * @copydoc ISocket::open()

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSocket.hpp
@@ -11,13 +11,11 @@ namespace communication_interfaces::sockets {
  * @brief Configuration parameters for a ZMQ socket
  */
 struct ZMQSocketConfiguration {
-  ZMQSocketConfiguration(std::string ip_address, std::string port, bool bind_socket, bool wait = false) :
-      ip_address(std::move(ip_address)), port(std::move(port)), bind_socket(bind_socket), wait(wait) {}
-
+  std::shared_ptr<zmq::context_t> context;
   std::string ip_address;
   std::string port;
-  bool bind_socket;
-  bool wait;
+  bool bind = true;
+  bool wait = true;
 };
 
 /**
@@ -47,16 +45,11 @@ public:
   bool send_bytes(const ByteArray& buffer) override;
 
 protected:
-    /**
-     * @brief Constructor taking the configuration struct
-     */
   /**
    * @brief Constructor taking the configuration struct
    * @param The configuration struct
-   * @param context The ZMQ context to be used for the sockets
-   * (it's recommended to only use one context per application)
    */
-  ZMQSocket(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context);
+  ZMQSocket(ZMQSocketConfiguration configuration);
 
   /**
    * @brief Bind or connect the socket on the desired IP/port
@@ -64,7 +57,6 @@ protected:
   void open_socket();
 
   ZMQSocketConfiguration config_; ///< Socket configuration struct
-  std::shared_ptr<zmq::context_t> context_; ///< ZMQ context
   std::shared_ptr<zmq::socket_t> socket_; ///< ZMQ socket
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSocket.hpp
@@ -7,6 +7,21 @@
 namespace communication_interfaces::sockets {
 
 /**
+ * @struct ZMQSocketConfiguration
+ * @brief Configuration parameters for a ZMQ socket
+ */
+struct ZMQSocketConfiguration {
+  ZMQSocketConfiguration(std::string ip_address, std::string port, bool bind_socket, bool wait = false) :
+      ip_address(std::move(ip_address)), port(std::move(port)), bind_socket(bind_socket), wait(wait) {}
+
+  std::string ip_address;
+  std::string port;
+  bool bind_socket;
+  bool wait;
+};
+
+/**
+ * @class ZMQSocket
  * @brief Abstract class to define a generic ZMQ socket
  */
 class ZMQSocket : public ISocket {
@@ -32,38 +47,24 @@ public:
   bool send_bytes(const ByteArray& buffer) override;
 
 protected:
-   /**
-    * @brief Add the parameters with no or default value to the map
-    * @param context The ZMQ context to be used for the sockets
-    * (it's recommended to only use one context per application)
-    */
-  explicit ZMQSocket(const std::shared_ptr<zmq::context_t>& context);
-
+    /**
+     * @brief Constructor taking the configuration struct
+     */
   /**
-   * @brief Add and set the parameters with the parameters given as argument
-   * @param parameters The list of parameters
+   * @brief Constructor taking the configuration struct
+   * @param The configuration struct
    * @param context The ZMQ context to be used for the sockets
-    * (it's recommended to only use one context per application)
+   * (it's recommended to only use one context per application)
    */
-  ZMQSocket(
-      const state_representation::ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context
-  );
+  ZMQSocket(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context);
 
   /**
    * @brief Bind or connect the socket on the desired IP/port
    */
   void open_socket();
 
+  ZMQSocketConfiguration config_; ///< Socket configuration struct
   std::shared_ptr<zmq::context_t> context_; ///< ZMQ context
   std::shared_ptr<zmq::socket_t> socket_; ///< ZMQ socket
-
-private:
-  /**
-   * @brief Validate and set parameters
-   * @param parameter A parameter interface pointer
-   */
-  void validate_and_set_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) final;
-
-  std::shared_ptr<state_representation::Parameter<bool>> wait_; ///< If false, send and receive are blocking
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSubscriber.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSubscriber.hpp
@@ -5,21 +5,15 @@
 namespace communication_interfaces::sockets {
 
 /**
+ * @class ZMQSubscriber
  * @brief Class to define a ZMQ subscriber
  */
 class ZMQSubscriber : public ZMQSocket {
 public:
   /**
-   * @copydoc ZMQSocket::ZMQSocket(const std::shared_ptr<zmq::context_t>&)
+   * @copydoc ZMQSocket::ZMQSocket(ZMQSocketConfiguration, const std::shared_ptr<zmq::context_t>&)
    */
-  explicit ZMQSubscriber(const std::shared_ptr<zmq::context_t>& context);
-
-  /**
-   * @copydoc ZMQSocket::ZMQSocket(const state_representation::ParameterInterfaceList&, const std::shared_ptr<zmq::context_t>&)
-   */
-  explicit ZMQSubscriber(
-      const state_representation::ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context
-  );
+  explicit ZMQSubscriber(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context);
 
   /**
    * @copydoc ISocket::open()

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSubscriber.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSubscriber.hpp
@@ -11,9 +11,9 @@ namespace communication_interfaces::sockets {
 class ZMQSubscriber : public ZMQSocket {
 public:
   /**
-   * @copydoc ZMQSocket::ZMQSocket(ZMQSocketConfiguration, const std::shared_ptr<zmq::context_t>&)
+   * @copydoc ZMQSocket::ZMQSocket(ZMQSocketConfiguration)
    */
-  explicit ZMQSubscriber(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context);
+  explicit ZMQSubscriber(ZMQSocketConfiguration configuration);
 
   /**
    * @copydoc ISocket::open()

--- a/source/communication_interfaces/src/sockets/UDPClient.cpp
+++ b/source/communication_interfaces/src/sockets/UDPClient.cpp
@@ -2,10 +2,7 @@
 
 namespace communication_interfaces::sockets {
 
-UDPClient::UDPClient() : UDPSocket() {}
-
-UDPClient::UDPClient(const std::list<std::shared_ptr<state_representation::ParameterInterface>>& parameters) :
-    UDPSocket(parameters) {}
+UDPClient::UDPClient(UDPSocketConfiguration configuration) : UDPSocket(std::move(configuration)) {}
 
 void UDPClient::open() {
   this->open_socket(false);

--- a/source/communication_interfaces/src/sockets/UDPServer.cpp
+++ b/source/communication_interfaces/src/sockets/UDPServer.cpp
@@ -2,10 +2,7 @@
 
 namespace communication_interfaces::sockets {
 
-UDPServer::UDPServer() : UDPSocket(), client_address_() {}
-
-UDPServer::UDPServer(const std::list<std::shared_ptr<state_representation::ParameterInterface>>& parameters) :
-    UDPSocket(parameters), client_address_() {}
+UDPServer::UDPServer(UDPSocketConfiguration configuration) : UDPSocket(std::move(configuration)) {}
 
 void UDPServer::open() {
   this->open_socket(true);

--- a/source/communication_interfaces/src/sockets/UDPSocket.cpp
+++ b/source/communication_interfaces/src/sockets/UDPSocket.cpp
@@ -1,5 +1,6 @@
 #include "communication_interfaces/sockets/UDPSocket.hpp"
 
+#include <cmath>
 #include <unistd.h>
 #include <sys/socket.h>
 
@@ -7,20 +8,11 @@
 
 namespace communication_interfaces::sockets {
 
-using namespace state_representation;
-
-UDPSocket::UDPSocket() :
-    server_address_(), buffer_size_(std::make_shared<Parameter<int>>("buffer_size")), server_fd_(), addr_len_() {
-  this->parameters_.insert_or_assign("ip_address", std::make_shared<Parameter<std::string>>("ip_address"));
-  this->parameters_.insert_or_assign("port", std::make_shared<Parameter<int>>("port"));
-  this->parameters_.insert_or_assign("enable_reuse", std::make_shared<Parameter<bool>>("enable_reuse", false));
-  this->parameters_.insert_or_assign(
-      "timeout_duration_sec", std::make_shared<Parameter<double>>("timeout_duration_sec", 0.0));
-  this->parameters_.insert(std::make_pair("buffer_size", this->buffer_size_));
-}
-
-UDPSocket::UDPSocket(const ParameterInterfaceList& parameters) : UDPSocket() {
-  this->set_parameters(parameters);
+UDPSocket::UDPSocket(UDPSocketConfiguration configuration) :
+    server_address_(), config_(std::move(configuration)), server_fd_(), addr_len_() {
+  if (this->config_.buffer_size <= 0) {
+    throw exceptions::SocketConfigurationException("Configuration parameter 'buffer_size' has to be greater than 0.");
+  }
 }
 
 UDPSocket::~UDPSocket() {
@@ -28,15 +20,11 @@ UDPSocket::~UDPSocket() {
 }
 
 void UDPSocket::open_socket(bool bind_socket) {
-  if (this->buffer_size_->is_empty()) {
-    throw exceptions::SocketConfigurationException("Parameter 'buffer_size' is empty.");
-  }
-
   try {
     this->addr_len_ = sizeof(this->server_address_);
     this->server_address_.sin_family = AF_INET;
-    this->server_address_.sin_addr.s_addr = inet_addr(this->get_parameter_value<std::string>("ip_address").c_str());
-    this->server_address_.sin_port = htons(this->get_parameter_value<int>("port"));
+    this->server_address_.sin_addr.s_addr = inet_addr(this->config_.ip_address.c_str());
+    this->server_address_.sin_port = htons(this->config_.port);
   } catch (const std::exception& ex) {
     throw exceptions::SocketConfigurationException("Socket configuration failed: " + std::string(ex.what()));
   }
@@ -45,7 +33,7 @@ void UDPSocket::open_socket(bool bind_socket) {
   if (this->server_fd_ < 0) {
     throw exceptions::SocketConfigurationException("Opening socket failed");
   }
-  if (this->get_parameter_value<bool>("enable_reuse")) {
+  if (this->config_.enable_reuse) {
     const int opt_reuse = 1;
     if (setsockopt(this->server_fd_, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt_reuse, sizeof(opt_reuse)) != 0) {
       throw exceptions::SocketConfigurationException("Setting socket option (enable reuse) failed");
@@ -57,12 +45,12 @@ void UDPSocket::open_socket(bool bind_socket) {
     }
   }
 
-  auto timeout_duration_sec = this->get_parameter_value<double>("timeout_duration_sec");
-  if (timeout_duration_sec > 0.0) {
+  if (this->config_.timeout_duration_sec > 0.0
+      && this->config_.timeout_duration_sec < std::numeric_limits<double>::max()) {
     timeval timeout{};
-    auto secs = std::floor(timeout_duration_sec);
+    auto secs = std::floor(this->config_.timeout_duration_sec);
     timeout.tv_sec = static_cast<long>(secs);
-    timeout.tv_usec = static_cast<long>((timeout_duration_sec - secs) * 1e6);
+    timeout.tv_usec = static_cast<long>((this->config_.timeout_duration_sec - secs) * 1e6);
     if (setsockopt(this->server_fd_, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
       throw exceptions::SocketConfigurationException("Setting socket timeout failed.");
     }
@@ -70,10 +58,9 @@ void UDPSocket::open_socket(bool bind_socket) {
 }
 
 bool UDPSocket::recvfrom(sockaddr_in& address, ByteArray& buffer) {
-  std::vector<char> local_buffer(this->buffer_size_->get_value());
+  std::vector<char> local_buffer(this->config_.buffer_size);
   auto receive_length = ::recvfrom(
-      this->server_fd_, local_buffer.data(), this->buffer_size_->get_value(), 0, (sockaddr*) &(address),
-      &(this->addr_len_));
+      this->server_fd_, local_buffer.data(), this->config_.buffer_size, 0, (sockaddr*) &(address), &(this->addr_len_));
   if (receive_length < 0) {
     return false;
   }
@@ -89,33 +76,6 @@ bool UDPSocket::sendto(const sockaddr_in& address, const ByteArray& buffer) cons
   int send_length = ::sendto(
       this->server_fd_, local_buffer.data(), local_buffer.size(), 0, (sockaddr*) &(address), this->addr_len_);
   return send_length == static_cast<int>(local_buffer.size());
-}
-
-void UDPSocket::validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) {
-  // TODO remove once this check is included in `assert_parameter_valid`
-  if (this->parameters_.find(parameter->get_name()) == this->parameters_.end()) {
-    throw state_representation::exceptions::InvalidParameterException(
-        "Invalid parameter '" + parameter->get_name() + "' for class UDPSocket.");
-  }
-  this->assert_parameter_valid(parameter);
-  if (parameter->is_empty()) {
-    throw state_representation::exceptions::InvalidParameterException(
-        "Parameter '" + parameter->get_name() + "' cannot be empty.");
-  }
-  if (parameter->get_name() == "timeout_duration_sec" && parameter->get_parameter_value<double>() < 0.0) {
-    throw state_representation::exceptions::InvalidParameterException(
-        "Parameter 'timeout_duration_sec' cannot be negative.");
-  }
-  if (parameter->get_name() == "buffer_size") {
-    int value = parameter->get_parameter_value<int>();
-    if (value < 0) {
-      throw state_representation::exceptions::InvalidParameterException(
-          "Parameter 'buffer_size' cannot be negative.");
-    }
-    this->parameters_.at(parameter->get_name())->set_parameter_value(value);
-  } else {
-    this->parameters_.insert_or_assign(parameter->get_name(), parameter);
-  }
 }
 
 void UDPSocket::close() {

--- a/source/communication_interfaces/src/sockets/UDPSocket.cpp
+++ b/source/communication_interfaces/src/sockets/UDPSocket.cpp
@@ -20,9 +20,6 @@ UDPSocket::~UDPSocket() {
 }
 
 void UDPSocket::open_socket(bool bind_socket) {
-  if (this->config_.buffer_size <= 0) {
-    throw exceptions::SocketConfigurationException("Socket configuration failed: 'buffer_size' must be greter than 0");
-  }
   try {
     this->addr_len_ = sizeof(this->server_address_);
     this->server_address_.sin_family = AF_INET;

--- a/source/communication_interfaces/src/sockets/UDPSocket.cpp
+++ b/source/communication_interfaces/src/sockets/UDPSocket.cpp
@@ -20,6 +20,9 @@ UDPSocket::~UDPSocket() {
 }
 
 void UDPSocket::open_socket(bool bind_socket) {
+  if (this->config_.buffer_size <= 0) {
+    throw exceptions::SocketConfigurationException("Socket configuration failed: 'buffer_size' must be greter than 0");
+  }
   try {
     this->addr_len_ = sizeof(this->server_address_);
     this->server_address_.sin_family = AF_INET;

--- a/source/communication_interfaces/src/sockets/ZMQPublisher.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQPublisher.cpp
@@ -2,12 +2,8 @@
 
 namespace communication_interfaces::sockets {
 
-using namespace state_representation;
-
-ZMQPublisher::ZMQPublisher(const std::shared_ptr<zmq::context_t>& context) : ZMQSocket(context) {}
-
-ZMQPublisher::ZMQPublisher(const ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context) :
-    ZMQSocket(parameters, context) {}
+ZMQPublisher::ZMQPublisher(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context) :
+    ZMQSocket(std::move(configuration), context) {}
 
 void ZMQPublisher::open() {
   this->socket_ = std::make_shared<zmq::socket_t>(*this->context_, ZMQ_PUB);

--- a/source/communication_interfaces/src/sockets/ZMQPublisher.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQPublisher.cpp
@@ -2,11 +2,10 @@
 
 namespace communication_interfaces::sockets {
 
-ZMQPublisher::ZMQPublisher(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context) :
-    ZMQSocket(std::move(configuration), context) {}
+ZMQPublisher::ZMQPublisher(ZMQSocketConfiguration configuration) : ZMQSocket(std::move(configuration)) {}
 
 void ZMQPublisher::open() {
-  this->socket_ = std::make_shared<zmq::socket_t>(*this->context_, ZMQ_PUB);
+  this->socket_ = std::make_shared<zmq::socket_t>(*this->config_.context, ZMQ_PUB);
   this->open_socket();
 }
 

--- a/source/communication_interfaces/src/sockets/ZMQSocket.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQSocket.cpp
@@ -4,20 +4,8 @@
 
 namespace communication_interfaces::sockets {
 
-using namespace state_representation;
-
-ZMQSocket::ZMQSocket(const std::shared_ptr<zmq::context_t>& context) :
-    context_(context), wait_(std::make_shared<Parameter<bool>>("wait", false)) {
-  this->parameters_.insert_or_assign("ip_address", std::make_shared<Parameter<std::string>>("ip_address"));
-  this->parameters_.insert_or_assign("port", std::make_shared<Parameter<int>>("port"));
-  this->parameters_.insert_or_assign("bind_socket", std::make_shared<Parameter<bool>>("bind_socket"));
-  this->parameters_.insert(std::make_pair("wait", this->wait_));
-}
-
-ZMQSocket::ZMQSocket(const ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context) :
-    ZMQSocket(context) {
-  this->set_parameters(parameters);
-}
+ZMQSocket::ZMQSocket(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context) :
+    config_(std::move(configuration)), context_(context) {}
 
 ZMQSocket::~ZMQSocket() {
   ZMQSocket::close();
@@ -25,9 +13,8 @@ ZMQSocket::~ZMQSocket() {
 
 void ZMQSocket::open_socket() {
   try {
-    auto address = "tcp://" + this->get_parameter_value<std::string>("ip_address") + ":"
-        + this->get_parameter_value<std::string>("port");
-    if (this->get_parameter_value<bool>("bind_socket")) {
+    auto address = "tcp://" + this->config_.ip_address + ":" + this->config_.port;
+    if (this->config_.bind_socket) {
       this->socket_->bind(address);
     } else {
       this->socket_->connect(address);
@@ -38,7 +25,7 @@ void ZMQSocket::open_socket() {
 }
 
 bool ZMQSocket::receive_bytes(ByteArray& buffer) {
-  zmq::recv_flags recv_flag = this->wait_->get_value() ? zmq::recv_flags::none : zmq::recv_flags::dontwait;
+  zmq::recv_flags recv_flag = this->config_.wait ? zmq::recv_flags::none : zmq::recv_flags::dontwait;
   zmq::message_t message;
   try {
     auto received = this->socket_->recv(message, recv_flag);
@@ -53,7 +40,7 @@ bool ZMQSocket::receive_bytes(ByteArray& buffer) {
 }
 
 bool ZMQSocket::send_bytes(const ByteArray& buffer) {
-  zmq::send_flags send_flags = this->wait_->get_value() ? zmq::send_flags::none : zmq::send_flags::dontwait;
+  zmq::send_flags send_flags = this->config_.wait ? zmq::send_flags::none : zmq::send_flags::dontwait;
   std::vector<char> local_buffer;
   buffer.copy_to(local_buffer);
   zmq::message_t msg(local_buffer.begin(), local_buffer.end());
@@ -62,19 +49,6 @@ bool ZMQSocket::send_bytes(const ByteArray& buffer) {
     return sent.has_value();
   } catch (const zmq::error_t&) {
     return false;
-  }
-}
-
-void ZMQSocket::validate_and_set_parameter(const std::shared_ptr<ParameterInterface>& parameter) {
-  this->assert_parameter_valid(parameter);
-  if (parameter->is_empty()) {
-    throw state_representation::exceptions::InvalidParameterException(
-        "Parameter '" + parameter->get_name() + "' cannot be empty.");
-  }
-  if (parameter->get_name() == "wait") {
-    this->parameters_.at(parameter->get_name())->set_parameter_value(parameter->get_parameter_value<bool>());
-  } else {
-    this->parameters_.insert_or_assign(parameter->get_name(), parameter);
   }
 }
 

--- a/source/communication_interfaces/src/sockets/ZMQSocket.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQSocket.cpp
@@ -4,8 +4,7 @@
 
 namespace communication_interfaces::sockets {
 
-ZMQSocket::ZMQSocket(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context) :
-    config_(std::move(configuration)), context_(context) {}
+ZMQSocket::ZMQSocket(ZMQSocketConfiguration configuration) : config_(std::move(configuration)) {}
 
 ZMQSocket::~ZMQSocket() {
   ZMQSocket::close();
@@ -14,7 +13,7 @@ ZMQSocket::~ZMQSocket() {
 void ZMQSocket::open_socket() {
   try {
     auto address = "tcp://" + this->config_.ip_address + ":" + this->config_.port;
-    if (this->config_.bind_socket) {
+    if (this->config_.bind) {
       this->socket_->bind(address);
     } else {
       this->socket_->connect(address);

--- a/source/communication_interfaces/src/sockets/ZMQSubscriber.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQSubscriber.cpp
@@ -2,12 +2,8 @@
 
 namespace communication_interfaces::sockets {
 
-using namespace state_representation;
-
-ZMQSubscriber::ZMQSubscriber(const std::shared_ptr<zmq::context_t>& context) : ZMQSocket(context) {}
-
-ZMQSubscriber::ZMQSubscriber(const ParameterInterfaceList& parameters, const std::shared_ptr<zmq::context_t>& context) :
-    ZMQSocket(parameters, context) {}
+ZMQSubscriber::ZMQSubscriber(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context) :
+    ZMQSocket(std::move(configuration), context) {}
 
 void ZMQSubscriber::open() {
   this->socket_ = std::make_shared<zmq::socket_t>(*this->context_, ZMQ_SUB);

--- a/source/communication_interfaces/src/sockets/ZMQSubscriber.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQSubscriber.cpp
@@ -2,11 +2,10 @@
 
 namespace communication_interfaces::sockets {
 
-ZMQSubscriber::ZMQSubscriber(ZMQSocketConfiguration configuration, const std::shared_ptr<zmq::context_t>& context) :
-    ZMQSocket(std::move(configuration), context) {}
+ZMQSubscriber::ZMQSubscriber(ZMQSocketConfiguration configuration) : ZMQSocket(std::move(configuration)) {}
 
 void ZMQSubscriber::open() {
-  this->socket_ = std::make_shared<zmq::socket_t>(*this->context_, ZMQ_SUB);
+  this->socket_ = std::make_shared<zmq::socket_t>(*this->config_.context, ZMQ_SUB);
   this->open_socket();
   this->socket_->set(zmq::sockopt::conflate, 1);
   this->socket_->set(zmq::sockopt::subscribe, "");

--- a/source/communication_interfaces/test/tests/test_udp_communication.cpp
+++ b/source/communication_interfaces/test/tests/test_udp_communication.cpp
@@ -9,25 +9,21 @@ using namespace communication_interfaces;
 class TestUDPSockets : public ::testing::Test {
 public:
   TestUDPSockets() {
-    ip_address_ = "127.0.0.1";
-    port_ = 5000;
-    buffer_size_ = 100;
+    config_ = {.ip_address = "127.0.0.1", .port = 5000, .buffer_size = 100};
   }
 
-  std::string ip_address_;
-  int port_;
-  int buffer_size_;
+  sockets::UDPSocketConfiguration config_{};
 };
 
 TEST_F(TestUDPSockets, SendReceive) {
   const std::string send_string = "Hello world!";
 
   // Create server socket and bind it to a port
-  sockets::UDPServer server({this->ip_address_, this->port_, this->buffer_size_});
+  sockets::UDPServer server(this->config_);
   ASSERT_NO_THROW(server.open());
 
   // Create client socket
-  sockets::UDPClient client({this->ip_address_, this->port_, this->buffer_size_});
+  sockets::UDPClient client(this->config_);
   ASSERT_NO_THROW(client.open());
 
   // Send test message from client to server
@@ -47,7 +43,8 @@ TEST_F(TestUDPSockets, SendReceive) {
 
 TEST_F(TestUDPSockets, Timeout) {
   // Create server socket and bind it to a port
-  sockets::UDPServer server({this->ip_address_, this->port_, this->buffer_size_, false, 5.0});
+  this->config_.timeout_duration_sec = 5.0;
+  sockets::UDPServer server(this->config_);
 
   // Try to receive a message from client, but expect timeout
   ByteArray received_bytes;
@@ -56,24 +53,24 @@ TEST_F(TestUDPSockets, Timeout) {
 
 TEST_F(TestUDPSockets, PortReuse) {
   // Create server socket and bind it to a port
-  sockets::UDPServer server1({this->ip_address_, this->port_, this->buffer_size_});
+  sockets::UDPServer server1(this->config_);
   server1.open();
 
   // Try to create a second server socket and bind it to the same port (expect failure)
-  sockets::UDPServer server2({this->ip_address_, this->port_, this->buffer_size_});
+  sockets::UDPServer server2(this->config_);
   EXPECT_THROW(server2.open(), exceptions::SocketConfigurationException);
 }
 
 TEST_F(TestUDPSockets, OpenClose) {
   // Create and open server socket
-  sockets::UDPServer server({this->ip_address_, this->port_, this->buffer_size_});
+  sockets::UDPServer server(this->config_);
   server.open();
 
   // Close server socket
   server.close();
 
   // Create and open client socket
-  sockets::UDPClient client({this->ip_address_, this->port_, this->buffer_size_});
+  sockets::UDPClient client(this->config_);
   client.open();
 
   // Try to send a message from the closed server socket (expect failure)

--- a/source/communication_interfaces/test/tests/test_udp_communication.cpp
+++ b/source/communication_interfaces/test/tests/test_udp_communication.cpp
@@ -9,23 +9,25 @@ using namespace communication_interfaces;
 class TestUDPSockets : public ::testing::Test {
 public:
   TestUDPSockets() {
-    params_.emplace_back(state_representation::make_shared_parameter<std::string>("ip_address", "127.0.0.1"));
-    params_.emplace_back(state_representation::make_shared_parameter<int>("port", 5000));
-    params_.emplace_back(state_representation::make_shared_parameter<int>("buffer_size", 100));
+    ip_address_ = "127.0.0.1";
+    port_ = 5000;
+    buffer_size_ = 100;
   }
 
-  std::list<std::shared_ptr<state_representation::ParameterInterface>> params_;
+  std::string ip_address_;
+  int port_;
+  int buffer_size_;
 };
 
 TEST_F(TestUDPSockets, SendReceive) {
   const std::string send_string = "Hello world!";
 
   // Create server socket and bind it to a port
-  sockets::UDPServer server(this->params_);
+  sockets::UDPServer server({this->ip_address_, this->port_, this->buffer_size_});
   ASSERT_NO_THROW(server.open());
 
   // Create client socket
-  sockets::UDPClient client(this->params_);
+  sockets::UDPClient client({this->ip_address_, this->port_, this->buffer_size_});
   ASSERT_NO_THROW(client.open());
 
   // Send test message from client to server
@@ -44,10 +46,8 @@ TEST_F(TestUDPSockets, SendReceive) {
 }
 
 TEST_F(TestUDPSockets, Timeout) {
-  this->params_.emplace_back(state_representation::make_shared_parameter<double>("timeout_duration_sec", 5.0));
-
   // Create server socket and bind it to a port
-  sockets::UDPServer server(this->params_);
+  sockets::UDPServer server({this->ip_address_, this->port_, this->buffer_size_, false, 5.0});
 
   // Try to receive a message from client, but expect timeout
   ByteArray received_bytes;
@@ -56,24 +56,24 @@ TEST_F(TestUDPSockets, Timeout) {
 
 TEST_F(TestUDPSockets, PortReuse) {
   // Create server socket and bind it to a port
-  sockets::UDPServer server1(this->params_);
+  sockets::UDPServer server1({this->ip_address_, this->port_, this->buffer_size_});
   server1.open();
 
   // Try to create a second server socket and bind it to the same port (expect failure)
-  sockets::UDPServer server2(this->params_);
+  sockets::UDPServer server2({this->ip_address_, this->port_, this->buffer_size_});
   EXPECT_THROW(server2.open(), exceptions::SocketConfigurationException);
 }
 
 TEST_F(TestUDPSockets, OpenClose) {
   // Create and open server socket
-  sockets::UDPServer server(this->params_);
+  sockets::UDPServer server({this->ip_address_, this->port_, this->buffer_size_});
   server.open();
 
   // Close server socket
   server.close();
 
   // Create and open client socket
-  sockets::UDPClient client(this->params_);
+  sockets::UDPClient client({this->ip_address_, this->port_, this->buffer_size_});
   client.open();
 
   // Try to send a message from the closed server socket (expect failure)

--- a/source/communication_interfaces/test/tests/test_udp_communication.cpp
+++ b/source/communication_interfaces/test/tests/test_udp_communication.cpp
@@ -9,10 +9,10 @@ using namespace communication_interfaces;
 class TestUDPSockets : public ::testing::Test {
 public:
   TestUDPSockets() {
-    config_ = {.ip_address = "127.0.0.1", .port = 5000, .buffer_size = 100};
+    config_ = {"127.0.0.1", 5000, 100};
   }
 
-  sockets::UDPSocketConfiguration config_{};
+  sockets::UDPSocketConfiguration config_;
 };
 
 TEST_F(TestUDPSockets, SendReceive) {

--- a/source/communication_interfaces/test/tests/test_zmq_communication.cpp
+++ b/source/communication_interfaces/test/tests/test_zmq_communication.cpp
@@ -10,21 +10,19 @@ using namespace std::chrono_literals;
 class TestZMQSockets : public ::testing::Test {
 public:
   TestZMQSockets() {
-    ip_address_ = "127.0.0.1";
-    port_ = "5000";
-    context_ = std::make_shared<zmq::context_t>(1);
+    auto context = std::make_shared<zmq::context_t>(1);
+    config_ = {context, "127.0.0.1", "4000"};
   }
 
-  std::shared_ptr<zmq::context_t> context_;
-  std::string ip_address_;
-  std::string port_;
+  sockets::ZMQSocketConfiguration config_;
 };
 
 TEST_F(TestZMQSockets, SendReceive) {
   const std::string send_string = "Hello world!";
 
-  sockets::ZMQPublisher publisher({this->ip_address_, this->port_, true}, this->context_);
-  sockets::ZMQSubscriber subscriber({this->ip_address_, this->port_, false}, this->context_);
+  sockets::ZMQPublisher publisher(this->config_);
+  this->config_.bind = false;
+  sockets::ZMQSubscriber subscriber(this->config_);
 
   publisher.open();
   subscriber.open();

--- a/source/communication_interfaces/test/tests/test_zmq_communication.cpp
+++ b/source/communication_interfaces/test/tests/test_zmq_communication.cpp
@@ -10,24 +10,21 @@ using namespace std::chrono_literals;
 class TestZMQSockets : public ::testing::Test {
 public:
   TestZMQSockets() {
-      params_.emplace_back(state_representation::make_shared_parameter<std::string>("ip_address", "127.0.0.1"));
-      params_.emplace_back(state_representation::make_shared_parameter<std::string>("port", "5000"));
-      context_ = std::make_shared<zmq::context_t>(1);
-    }
+    ip_address_ = "127.0.0.1";
+    port_ = "5000";
+    context_ = std::make_shared<zmq::context_t>(1);
+  }
 
-    std::shared_ptr<zmq::context_t> context_;
-    state_representation::ParameterInterfaceList params_;
+  std::shared_ptr<zmq::context_t> context_;
+  std::string ip_address_;
+  std::string port_;
 };
 
 TEST_F(TestZMQSockets, SendReceive) {
   const std::string send_string = "Hello world!";
 
-  this->params_.emplace_back(state_representation::make_shared_parameter<bool>("bind_socket", true));
-  sockets::ZMQPublisher publisher(this->params_, this->context_);
-
-  this->params_.pop_back();
-  this->params_.emplace_back(state_representation::make_shared_parameter<bool>("bind_socket", false));
-  sockets::ZMQSubscriber subscriber(this->params_, this->context_);
+  sockets::ZMQPublisher publisher({this->ip_address_, this->port_, true}, this->context_);
+  sockets::ZMQSubscriber subscriber({this->ip_address_, this->port_, false}, this->context_);
 
   publisher.open();
   subscriber.open();

--- a/source/dev-server.sh
+++ b/source/dev-server.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-CONTROL_LIBRARIES_BRANCH=develop
 REMOTE_SSH_PORT=4420
 
 IMAGE_NAME=aica-technology/communication-interfaces

--- a/source/install.sh
+++ b/source/install.sh
@@ -71,20 +71,6 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-$(pkg-config --exists state_representation) || exit 1
-if [ "$?" == 1 ]; then
-  echo ">>> STATE REPRESENTATION LIBRARY NOT FOUND!"
-  echo ">>> Install state_representation from https://github.com/aica-technology/control-libraries/source"
-  exit 1
-fi
-
-$(pkg-config --exists clproto) || exit 1
-if [ "$?" == 1 ]; then
-  echo ">>> CL PROTO LIBRARY NOT FOUND!"
-  echo ">>> Install clproto from https://github.com/aica-technology/control-libraries/protocol"
-  exit 1
-fi
-
 echo ">>> INSTALLING ZMQ DEPENDENCIES"
 install_cppzmq || exit 1
 


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- #35 

<!-- Required: explain how the PR addresses the parent issue -->
As proposed by @LouisBrunner, this PR removes the dependency on `state_representation::ParameterMap` and constructs the sockets via configuration structs. When we discussed this, there was the idea of using C++20 designated initializer lists (`config c = {.first = 1.0, .second = 2.0}`) but as this is a C++20 feature, I don't think we should use it. Additionally, this syntax is not compatible with user-declared constructors for structs and I would prefer to declare the struct constructors myself, as some attributes should not have a default value.

Any suggestions welcome here, if we can use C++20 features and if we want to do input checking instead of custom constructors, I'm happy to change it.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 15 minutes
Review by commit

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->