### PR TITLE
fix: proper CMake syntax when cppzmq has already been installed

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -40,7 +40,7 @@ include(FindPkgConfig)
 
 add_project_dependency(control_libraries 7.0.0 REQUIRED COMPONENTS state_representation)
 add_project_dependency(clproto 7.0.0 REQUIRED)
-if (NOT ${cppzmq_FOUND}) # provided by parent CMakeLists.txt (if used)
+if (NOT cppzmq_POPULATED) # provided by parent CMakeLists.txt (if used)
   add_project_dependency(cppzmq 4.7.1 REQUIRED)
 endif()
 

--- a/source/communication_interfaces/CMakeLists.txt
+++ b/source/communication_interfaces/CMakeLists.txt
@@ -38,7 +38,7 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(FindPkgConfig)
 
-if (NOT ${cppzmq_FOUND}) # provided by parent CMakeLists.txt (if used)
+if (NOT cppzmq_POPULATED) # provided by parent CMakeLists.txt (if used)
   add_project_dependency(cppzmq 4.7.1 REQUIRED)
 endif()
 


### PR DESCRIPTION
## Description

As reported by @domire8.

Note: `docker build . -f Dockerfile.ci --target test` does the same thing as `build-test.sh`.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 1 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->