### PR TITLE
Set ZMQSubscriber socket options before opening the socket

### DIFF
--- a/source/communication_interfaces/src/sockets/ZMQSubscriber.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQSubscriber.cpp
@@ -6,9 +6,9 @@ ZMQSubscriber::ZMQSubscriber(ZMQSocketConfiguration configuration) : ZMQSocket(s
 
 void ZMQSubscriber::open() {
   this->socket_ = std::make_shared<zmq::socket_t>(*this->config_.context, ZMQ_SUB);
-  this->open_socket();
   this->socket_->set(zmq::sockopt::conflate, 1);
   this->socket_->set(zmq::sockopt::subscribe, "");
+  this->open_socket();
 }
 
 bool ZMQSubscriber::send_bytes(const std::string&) {


### PR DESCRIPTION
* The conflate option was not applied if the option is set after connection

<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

Bugfix to be tested. The ZMQ Pub / Sub was buffering messages because the conflate option was not correctly applied.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 1 minute

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->