### PR TITLE
fix(ci): fix permissions on HOME

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,5 @@
 FROM ghcr.io/aica-technology/ros2-modulo-control:humble as base
+USER ${USER}
 
 FROM base as apt-dependencies
 RUN <<HEREDOC
@@ -52,16 +53,19 @@ xargs -a /tmp/new-packages.txt dpkg-query -L \
 HEREDOC
 
 FROM base as python
-COPY --chown=${USER} ./python /python
+COPY --chown=${USER}:${USER} ./python /python
 RUN \
   --mount=type=cache,target=${HOME}/.cache,id=pip-${TARGETPLATFORM},uid=1000 \
   --mount=type=ssh,uid=1000 \
   python3 -m pip install --prefix=/tmp/python /python
+RUN mkdir -p /tmp/python-home/${HOME}/.local/lib/python3.10/ \
+  && mv /tmp/python/local/lib/python3.10/dist-packages/ /tmp/python-home/${HOME}/.local/lib/python3.10/site-packages/ \
+  && sudo chown root:root /tmp/python-home/home/
 
 FROM base as code
 WORKDIR /src
 COPY --from=apt-dependencies /tmp/apt /
-COPY --chown=${USER} . /src
+COPY --chown=${USER}:${USER} . /src
 
 FROM code as development
 COPY --from=python /tmp/python/local/lib/python3.10/dist-packages/ ${HOME}/.local/lib/python3.10/site-packages/
@@ -92,4 +96,4 @@ RUN \
 FROM scratch as production
 COPY --from=apt-dependencies /tmp/apt /
 COPY --from=install /tmp/net-ifaces /usr/local
-COPY --from=python /tmp/python/local/lib/python3.10/dist-packages/ /home/ros2/.local/lib/python3.10/site-packages/
+COPY --from=python /tmp/python-home/ /

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -58,9 +58,8 @@ RUN \
   --mount=type=cache,target=${HOME}/.cache,id=pip-${TARGETPLATFORM},uid=1000 \
   --mount=type=ssh,uid=1000 \
   python3 -m pip install --prefix=/tmp/python /python
-RUN mkdir -p /tmp/python-home/${HOME}/.local/lib/python3.10/ \
-  && mv /tmp/python/local/lib/python3.10/dist-packages/ /tmp/python-home/${HOME}/.local/lib/python3.10/site-packages/ \
-  && sudo chown root:root /tmp/python-home/home/
+RUN mkdir -p /tmp/python-home/${USER}/.local/lib/python3.10/ \
+  && mv /tmp/python/local/lib/python3.10/dist-packages/ /tmp/python-home/${USER}/.local/lib/python3.10/site-packages/
 
 FROM base as code
 WORKDIR /src
@@ -68,7 +67,7 @@ COPY --from=apt-dependencies /tmp/apt /
 COPY --chown=${USER}:${USER} . /src
 
 FROM code as development
-COPY --from=python /tmp/python/local/lib/python3.10/dist-packages/ ${HOME}/.local/lib/python3.10/site-packages/
+COPY --from=python /tmp/python-home/ /home
 
 FROM code as build
 RUN \
@@ -83,7 +82,7 @@ RUN \
   --mount=type=ssh,uid=1000 \
   cmake -B build -DBUILD_TESTING=ON \
   && CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target all test
-COPY --from=python /tmp/python/local/lib/python3.10/dist-packages/ ${HOME}/.local/lib/python3.10/site-packages/
+COPY --from=python /tmp/python-home/ /home
 RUN python3 -m unittest discover python/test --verbose
 
 FROM build as install
@@ -96,4 +95,4 @@ RUN \
 FROM scratch as production
 COPY --from=apt-dependencies /tmp/apt /
 COPY --from=install /tmp/net-ifaces /usr/local
-COPY --from=python /tmp/python-home/ /
+COPY --from=python /tmp/python-home/ /home


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
Fixes #53 

<!-- Required: explain how the PR addresses the parent issue -->
The issue stems from `COPY --from=python /tmp/python/local/lib/python3.10/dist-packages/ /home/ros2/.local/lib/python3.10/site-packages/` which has to create the `/home/ros2/.local/lib/python3.10/site-packages/` in a scratch image, which only has a root user (actually it has none which means it puts uid 1, which means root).

I solve this issue by pre-creating the whole folder structure, so it's owned by the right users and avoiding the Docker implicit creation during `COPY`. This is also a bit better to isolate the Python folder architecture in its own stage instead of putting it everywhere.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 1 minute

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->