### PR TITLE
build: fix test stage in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ FROM build as test
 ARG TARGETPLATFORM
 ARG CACHEID
 RUN --mount=type=cache,target=./build,id=cmake-${TARGETPLATFORM}-${CACHEID},uid=1000 \
-  cmake -B build -DBUILD_TESTING=ON && CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target test
+  cmake -B build -DBUILD_TESTING=ON && cd build && make && CTEST_OUTPUT_ON_FAILURE=1 make test
 COPY --from=install /tmp/communication-interfaces /usr/local
 COPY --from=python /tmp/python-home/ /home
 COPY --from=python /python/test /python/test


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
The tests on develop branch are currently failing, see [here](https://github.com/aica-technology/network-interfaces/actions/runs/6237357522). I can indeed reproduce the error locally if I run the tests without cache (`./build.sh -r --test`). The error is
```
 #13 0.718 -- Build files have been written to: /src/build
#13 0.743 Running tests...
#13 0.753 Test project /src/build
#13 0.754     Start 1: test_communication_interfaces
#13 0.754 Could not find executable /src/build/test_communication_interfaces
#13 0.754 Looked in the following places:
#13 0.754 /src/build/test_communication_interfaces
#13 0.754 /src/build/test_communication_interfaces
#13 0.754 /src/build/Release/test_communication_interfaces
#13 0.754 /src/build/Release/test_communication_interfaces
#13 0.754 /src/build/Debug/test_communication_interfaces
#13 0.754 /src/build/Debug/test_communication_interfaces
#13 0.754 /src/build/MinSizeRel/test_communication_interfaces
#13 0.754 /src/build/MinSizeRel/test_communication_interfaces
#13 0.754 /src/build/RelWithDebInfo/test_communication_interfaces
#13 0.754 /src/build/RelWithDebInfo/test_communication_interfaces
#13 0.754 /src/build/Deployment/test_communication_interfaces
#13 0.754 /src/build/Deployment/test_communication_interfaces
#13 0.754 /src/build/Development/test_communication_interfaces
#13 0.754 /src/build/Development/test_communication_interfaces
#13 0.754 src/build/test_communication_interfaces
#13 0.754 src/build/test_communication_interfaces
#13 0.754 src/build/Release/test_communication_interfaces
#13 0.754 src/build/Release/test_communication_interfaces
#13 0.754 src/build/Debug/test_communication_interfaces
#13 0.754 src/build/Debug/test_communication_interfaces
#13 0.754 src/build/MinSizeRel/test_communication_interfaces
#13 0.754 src/build/MinSizeRel/test_communication_interfaces
#13 0.754 src/build/RelWithDebInfo/test_communication_interfaces
#13 0.754 src/build/RelWithDebInfo/test_communication_interfaces
#13 0.754 src/build/Deployment/test_communication_interfaces
#13 0.754 src/build/Deployment/test_communication_interfaces
#13 0.754 src/build/Development/test_communication_interfaces
#13 0.754 src/build/Development/test_communication_interfaces
#13 0.754 1/1 Test #1: test_communication_interfaces ....***Not Run   0.00 sec
#13 0.754 Unable to find executable: /src/build/test_communication_interfaces
#13 0.754 
#13 0.754 0% tests passed, 1 tests failed out of 1
#13 0.754 
#13 0.754 Total Test time (real) =   0.00 sec
#13 0.754 
#13 0.754 The following tests FAILED:
#13 0.754 Errors while running CTest
#13 0.754 	  1 - test_communication_interfaces (Not Run)
#13 0.755 gmake: *** [Makefile:71: test] Error 8
#13 ERROR: process "/bin/sh -c cmake -B build -DBUILD_TESTING=ON && CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target test" did not complete successfully: exit code: 2
```
I tried to find help but couldn't find any. My suggestion is going back to using `make test` instead of `cmake --target test` as this doesn't seem to cause problems.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->