### PR TITLE
fix(python): avoid removal of null characters in bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Release Versions:
 
+- [2.0.1](#201)
 - [2.0.0](#200)
 - [1.4.1](#141)
 - [1.4.0](#140)
@@ -11,6 +12,13 @@ Release Versions:
 - [1.0.0](#100)
 - [0.2.0](#020)
 - [0.1.0](#010)
+
+## 2.0.1
+
+Version 2.0.1 contains a hotfix that enables socket communiction with any serialized message in Python, which was not
+possible before due to an error in the bindings.
+
+- fix(python): avoid removal of null characters in bindings (#66)
 
 ## 2.0.0
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE_NAME=ghcr.io/aica-technology/communication-interfaces
+IMAGE_NAME=ghcr.io/aica-technology/network-interfaces
 IMAGE_TAG=latest
 
 ROS2_VERSION=humble

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ import pkgconfig
 from pybind11.setup_helpers import ParallelCompile, Pybind11Extension, build_ext, naive_recompile
 from setuptools import setup
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 try:
     status = pkgconfig.installed('communication_interfaces', f'>= {__version__}')

--- a/python/src/communication_interfaces_bindings.cpp
+++ b/python/src/communication_interfaces_bindings.cpp
@@ -44,7 +44,6 @@ PYBIND11_MODULE(communication_interfaces, m) {
             std::string buffer;
             auto res = socket.receive_bytes(buffer);
             if (res) {
-              buffer.erase(std::find(buffer.begin(), buffer.end(), '\0'), buffer.end());
               return py::bytes(buffer);
             } else {
               return py::none();

--- a/python/test/test_tcp.py
+++ b/python/test/test_tcp.py
@@ -16,7 +16,7 @@ class TestTCPCommunication:
         response = self.server.receive_bytes()
         if response is None:
             pytest.fail("No response from client")
-        assert response.decode("utf-8") == self.client_message
+        assert response.decode("utf-8").rstrip("\x00") == self.client_message
         assert self.server.send_bytes(self.server_message)
 
     def test_comm(self):
@@ -28,4 +28,4 @@ class TestTCPCommunication:
         assert self.client.send_bytes(self.client_message)
         response = self.client.receive_bytes()
         assert response
-        assert response.decode("utf-8") == self.server_message
+        assert response.decode("utf-8").rstrip("\x00") == self.server_message

--- a/python/test/test_udp.py
+++ b/python/test/test_udp.py
@@ -24,7 +24,7 @@ def client(udp_config):
 
 
 def test_send_receive(server, client):
-    send_string = b"Hello world"
+    send_string = "Hello world"
 
     try:
         server.open()
@@ -39,7 +39,7 @@ def test_send_receive(server, client):
     assert client.send_bytes(send_string)
     response = server.receive_bytes()
     assert response
-    assert response == send_string
+    assert response.decode("utf-8").rstrip("\x00") == send_string
 
 
 def test_timeout(udp_config):

--- a/source/communication_interfaces/CMakeLists.txt
+++ b/source/communication_interfaces/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-set(COMMUNICATION_INTERFACES_VERSION 1.0.0)
+set(COMMUNICATION_INTERFACES_VERSION 1.0.1)
 project(communication_interfaces VERSION ${COMMUNICATION_INTERFACES_VERSION})
 
 option(BUILD_TESTING "Build tests." OFF)


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
The `receive_bytes` in python is indeed causing some troubles. The removal of the null characters at the end of the received buffer is not a good idea, because this will "destroy" clproto messages that have zeros (for example a zero joint state). Returning the buffer just like that is also not a good idea, because then clproto messages would be decoded, which will throw exceptions.

Unfortunately, I don't see a better way of handling this right now. I don't think we can make a general assumption about the messages that we receive, so its ultimately the users responsibility to correctly decode and `rstrip` the received message.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->