### PR TITLE
feat: add is_opened flag to socket base class

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "name": "network interfaces",
+    "remoteUser": "ros2",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": "..",
+        "target": "development",
+        "args": {
+            "ROS2_VERSION": "iron"
+        }
+    },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/ros2/.devcontainer,type=bind,consistency=cached",
+    "workspaceFolder": "/home/ros2/.devcontainer",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools-extension-pack",
+                "eamodio.gitlens"
+            ]
+        }
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.idea
 *cmake-build-debug*
+build/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,15 @@
+{
+    "configurations": [
+        {
+            "name": "AMD",
+            "includePath": [
+                "/home/ros2/.devcontainer/source/communication_interfaces/include/**"
+            ],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c17",
+            "cppStandard": "gnu++17",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cmake.sourceDirectory": "/home/ros2/.devcontainer/source/communication_interfaces",
+    "cmake.configureArgs": [ "-DBUILD_TESTING=ON" ],
+    "C_Cpp.clang_format_style": "file:/home/ros2/.clang-format"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Release Versions:
 - [0.2.0](#020)
 - [0.1.0](#010)
 
+## Upcoming changes (in development)
+
+- feat: add is_opened flag to socket base class (#68)
+
 ## 2.0.1
 
 Version 2.0.1 contains a hotfix that enables socket communiction with any serialized message in Python, which was not

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ respectively.
 #### Implementing a derived socket class
 
 To use this class, create a subclass that inherits from it and implement its pure virtual functions. The pure virtual
-functions are `open()`, `receive_bytes(std::string&)`, and `send_bytes(const std::string&)`.
+functions are `on_open()`, `on_receive_bytes(std::string&)`, and `on_send_bytes(const std::string&)`.
 
 Configuration parameters should be passed with a configuration struct, resulting in a single argument constructor.
 
-The `close()` function can optionally be overridden to perform steps to disconnect and close the socket communication.
-If a derived class defines any cleanup behavior in `close()`, it should also be invoked statically and explicitly
+The `on_close()` function can optionally be overridden to perform steps to disconnect and close the socket communication.
+If a derived class defines any cleanup behavior in `on_close()`, it should also be invoked statically and explicitly
 in the destructor of the derived class.
 
 An example is given below.
@@ -45,13 +45,14 @@ public:
   
   ~DerivedSocket() override;
   
-  void open() override;
+private:
+  void on_open() override;
   
-  bool receive_bytes(std::string& buffer) override;
+  bool on_receive_bytes(std::string& buffer) override;
 
-  bool send_bytes(const std::string& buffer) override;
+  bool on_send_bytes(const std::string& buffer) override;
   
-  void close() override;
+  void on_close() override;
 }
 ```
 
@@ -62,24 +63,24 @@ DerivedSocket::DerivedSocket(DerivedSocketConfig configuraiton) {
 }
 
 DerivedSocket::~DerivedSocket() {
-  DerivedSocket::close();
+  DerivedSocket::on_close();
 }
 
-void DerivedSocket::open() {
+void DerivedSocket::on_open() {
   // Configure and open the socket
 }
 
-bool DerivedSocket::receive_bytes(std::string& buffer) {
+bool DerivedSocket::on_receive_bytes(std::string& buffer) {
   // Read the contents of the socket into the buffer and return true on success. Otherwise, return false.
   return true;
 }
 
-bool DerivedSocket::send_bytes(const std::string& buffer) {
+bool DerivedSocket::on_send_bytes(const std::string& buffer) {
   // Write the contents of the buffer onto the socket and return true on success. Otherwise, return false.
   return true;
 }
 
-void DerivedSocket::close() {
+void DerivedSocket::on_close() {
   // Perform clean-up steps here
 }
 ```

--- a/build.sh
+++ b/build.sh
@@ -7,19 +7,19 @@ ROS2_VERSION=humble
 
 HELP_MESSAGE="Usage: build.sh [options]
 Options:
-  --test                      Target the test layer to run the tests.
+  --test                    Target the test layer to run the tests.
 
-  --ros2-version <VERSION>    Specify the version of ROS 2 to use.
-                              (default: $ROS2_VERSION)
+  --ros2-version <VERSION>  Specify the version of ROS 2 to use.
+                            (default: $ROS2_VERSION)
 
-  -v|--verbose             Set the build output to verbose.
+  -v|--verbose              Set the build output to verbose.
 
-  --cache-id <id>          Invalidate the mount cache (e.g. CMake build folder)
-                           by providing a new value.
+  --cache-id <id>           Invalidate the mount cache (e.g. CMake build folder)
+                            by providing a new value.
 
-  -r|--no-cache            Invalidate all cache (layer + mount).
+  -r|--no-cache             Invalidate all cache (layer + mount).
 
-  -h|--help                Show this help message.
+  -h|--help                 Show this help message.
 "
 
 TEST=0

--- a/python/src/communication_interfaces_bindings.cpp
+++ b/python/src/communication_interfaces_bindings.cpp
@@ -8,19 +8,6 @@
 
 using namespace communication_interfaces;
 
-class PySocket : public sockets::ISocket, public std::enable_shared_from_this<PySocket> {
-public:
-  using sockets::ISocket::ISocket;
-
-  void open() override { PYBIND11_OVERRIDE_PURE(void, ISocket, open, ); }
-
-  bool receive_bytes(std::string& buffer) override { PYBIND11_OVERRIDE_PURE(bool, ISocket, receive_bytes, buffer); }
-
-  bool send_bytes(const std::string& buffer) override { PYBIND11_OVERRIDE_PURE(bool, ISocket, send_bytes, buffer); }
-
-  void close() override { PYBIND11_OVERRIDE(void, ISocket, close, ); }
-};
-
 PYBIND11_MODULE(communication_interfaces, m) {
   m.doc() = "Python bindings for communication interfaces";
 
@@ -36,7 +23,7 @@ PYBIND11_MODULE(communication_interfaces, m) {
 
   auto m_sub_sock = m.def_submodule("sockets", "Submodule for communication interfaces sockets");
 
-  py::class_<sockets::ISocket, std::shared_ptr<sockets::ISocket>, PySocket>(m_sub_sock, "ISocket")
+  py::class_<sockets::ISocket, std::shared_ptr<sockets::ISocket>>(m_sub_sock, "ISocket")
       .def("open", &sockets::ISocket::open, "Perform configuration steps to open the socket for communication")
       .def(
           "receive_bytes",

--- a/python/test/test_tcp.py
+++ b/python/test/test_tcp.py
@@ -2,6 +2,7 @@ import multiprocessing
 import pytest
 import time
 
+from communication_interfaces.exceptions import SocketConfigurationError
 from communication_interfaces.sockets import TCPClientConfiguration, TCPClient, TCPServerConfiguration, TCPServer
 
 
@@ -29,3 +30,27 @@ class TestTCPCommunication:
         response = self.client.receive_bytes()
         assert response
         assert response.decode("utf-8").rstrip("\x00") == self.server_message
+
+        buffer = ""
+        self.server.close()
+        with pytest.raises(SocketConfigurationError):
+            self.server.receive_bytes()
+        with pytest.raises(SocketConfigurationError):
+            self.server.send_bytes(buffer)
+        self.client.close()
+        with pytest.raises(SocketConfigurationError):
+            self.client.receive_bytes()
+        with pytest.raises(SocketConfigurationError):
+            self.client.send_bytes(buffer)
+
+    def test_not_open(self):
+        buffer = ""
+        with pytest.raises(SocketConfigurationError):
+            self.server.receive_bytes()
+        with pytest.raises(SocketConfigurationError):
+            self.server.send_bytes(buffer)
+
+        with pytest.raises(SocketConfigurationError):
+            self.client.receive_bytes()
+        with pytest.raises(SocketConfigurationError):
+            self.client.send_bytes(buffer)

--- a/python/test/test_udp.py
+++ b/python/test/test_udp.py
@@ -60,8 +60,35 @@ def test_port_reuse(udp_config, server):
         server2.open()
 
 
-def test_open_close(server):
+def test_open_close(udp_config):
+    buffer = ""
+    udp_config.timeout_duration_sec = 0.5
+    server = UDPServer(udp_config)
+    with pytest.raises(SocketConfigurationError):
+        server.send_bytes(buffer)
+    with pytest.raises(SocketConfigurationError):
+        server.receive_bytes()
     server.open()
-    server.close()
+    assert server.send_bytes("test")
+    assert not server.receive_bytes()
 
-    assert not server.send_bytes("")
+    server.close()
+    with pytest.raises(SocketConfigurationError):
+        server.send_bytes(buffer)
+    with pytest.raises(SocketConfigurationError):
+        server.receive_bytes()
+
+    client = UDPClient(udp_config)
+    with pytest.raises(SocketConfigurationError):
+        client.send_bytes(buffer)
+    with pytest.raises(SocketConfigurationError):
+        client.receive_bytes()
+    client.open()
+    assert client.send_bytes("test")
+    assert not client.receive_bytes()
+
+    client.close()
+    with pytest.raises(SocketConfigurationError):
+        client.send_bytes(buffer)
+    with pytest.raises(SocketConfigurationError):
+        client.receive_bytes()

--- a/python/test/test_zmq.py
+++ b/python/test/test_zmq.py
@@ -1,6 +1,7 @@
 import pytest
 import time
 
+from communication_interfaces.exceptions import SocketConfigurationError
 from communication_interfaces.sockets import ZMQContext, ZMQSocketConfiguration, ZMQPublisher, ZMQSubscriber, \
     ZMQCombinedSocketsConfiguration, ZMQPublisherSubscriber
 
@@ -71,3 +72,18 @@ def test_send_receive_combined(zmq_context):
 
     server.close()
     client.close()
+
+
+def test_open_close(zmq_config):
+    buffer = ""
+    socket = ZMQPublisher(zmq_config)
+    with pytest.raises(SocketConfigurationError):
+        socket.send_bytes(buffer)
+    with pytest.raises(SocketConfigurationError):
+        socket.receive_bytes()
+
+    socket.open()
+    assert socket.send_bytes("test")
+    socket.close()
+    with pytest.raises(SocketConfigurationError):
+        socket.send_bytes(buffer)

--- a/source/communication_interfaces/CMakeLists.txt
+++ b/source/communication_interfaces/CMakeLists.txt
@@ -52,6 +52,7 @@ if (NOT cppzmq_POPULATED)
 endif()
 
 add_library(${PROJECT_NAME} SHARED
+        ${PROJECT_SOURCE_DIR}/src/sockets/ISocket.cpp
         ${PROJECT_SOURCE_DIR}/src/sockets/UDPSocket.cpp
         ${PROJECT_SOURCE_DIR}/src/sockets/UDPClient.cpp
         ${PROJECT_SOURCE_DIR}/src/sockets/UDPServer.cpp

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ISocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ISocket.hpp
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "communication_interfaces/exceptions/SocketConfigurationException.hpp"
+
 namespace communication_interfaces::sockets {
 
 /**
@@ -23,25 +25,56 @@ public:
    * @brief Perform configuration steps to open the socket for communication
    * @throws SocketConfigurationException if opening fails
    */
-  virtual void open() = 0;
+  void open();
+
+  /**
+   * @brief Receive bytes from the socket
+   * @param buffer The buffer to fill with the received bytes
+   * @return True if bytes were received, false otherwise
+   * @throws SocketConfigurationException if socket has not been opened yet
+   */
+  bool receive_bytes(std::string& buffer);
+
+  /**
+   * @brief Send bytes to the socket
+   * @param buffer The buffer with the bytes to send
+   * @return True if bytes were sent, false otherwise
+   * @throws SocketConfigurationException if socket has not been opened yet
+   */
+  bool send_bytes(const std::string& buffer);
+
+  /**
+   * @brief Perform steps to disconnect and close the socket communication
+   */
+  void close();
+
+protected:
+  /**
+   * @brief Perform configuration steps to open the socket for communication
+   * @throws SocketConfigurationException if opening fails
+   */
+  virtual void on_open() = 0;
 
   /**
    * @brief Receive bytes from the socket
    * @param buffer The buffer to fill with the received bytes
    * @return True if bytes were received, false otherwise
    */
-  virtual bool receive_bytes(std::string& buffer) = 0;
+  virtual bool on_receive_bytes(std::string& buffer) = 0;
 
   /**
    * @brief Send bytes to the socket
    * @param buffer The buffer with the bytes to send
    * @return True if bytes were sent, false otherwise
    */
-  virtual bool send_bytes(const std::string& buffer) = 0;
+  virtual bool on_send_bytes(const std::string& buffer) = 0;
 
   /**
    * @brief Perform steps to disconnect and close the socket communication
    */
-  virtual void close() {}
+  virtual void on_close() {};
+
+private:
+  bool opened_ = false;
 };
 }// namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/TCPClient.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/TCPClient.hpp
@@ -22,13 +22,13 @@ public:
    */
   explicit TCPClient(TCPClientConfiguration configuration);
 
+private:
   /**
-   * @copydoc ISocket::open()
+   * @copydoc ISocket::on_open()
    * @details Connect the client socket to the server
    */
-  void open() override;
+  void on_open() override;
 
-private:
   TCPClientConfiguration config_; ///< Socket configuration struct
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/TCPServer.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/TCPServer.hpp
@@ -27,19 +27,20 @@ public:
    */
   ~TCPServer() override;
 
+private:
   /**
-   * @copydoc ISocket::open()
+   * @copydoc ISocket::on_open()
    * @details Wait for connection requests from clients and accept new connections. This method blocks until a
    * connection is established
    */
-  void open() override;
+  void on_open() override;
 
   /**
-   * @brief Close the sockets
+   * @copydoc ISocket::on_close()
    */
-  void close() override;
+  void on_close() override;
 
-private:
+
   TCPServerConfiguration config_; ///< Socket configuration struct
   int server_fd_; ///< File descriptor of the connected server socket
 };

--- a/source/communication_interfaces/include/communication_interfaces/sockets/TCPSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/TCPSocket.hpp
@@ -18,23 +18,23 @@ public:
    */
   ~TCPSocket() override;
 
-  /**
-   * @copydoc ISocket::receive_bytes(std::string&)
-   */
-  bool receive_bytes(std::string& buffer) override;
-
-  /**
-   * @copydoc ISocket::receive_bytes(std::string&)
-   */
-  bool send_bytes(const std::string& buffer) override;
-
-  /**
-   * @brief Close the socket
-   */
-  void close() override;
-
 protected:
   explicit TCPSocket(int buffer_size);
+
+  /**
+   * @copydoc ISocket::on_receive_bytes(std::string&)
+   */
+  bool on_receive_bytes(std::string& buffer) override;
+
+  /**
+   * @copydoc ISocket::on_receive_bytes(std::string&)
+   */
+  bool on_send_bytes(const std::string& buffer) override;
+
+  /**
+   * @copydoc ISocket::on_close(std::string&)
+   */
+  void on_close() override;
 
   sockaddr_in server_address_; ///< Address of the TCP server
   int socket_fd_; ///< File descriptor of the socket

--- a/source/communication_interfaces/include/communication_interfaces/sockets/UDPClient.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/UDPClient.hpp
@@ -15,19 +15,20 @@ public:
    */
   UDPClient(UDPSocketConfiguration configuration);
 
+private:
   /**
-   * @copydoc ISocket::open()
+   * @copydoc ISocket::on_open()
    */
-  void open() override;
+  void on_open() override;
 
   /**
-   * @copydoc ISocket::receive_bytes(std::string&)
+   * @copydoc ISocket::on_receive_bytes(std::string&)
    */
-  bool receive_bytes(std::string& buffer) override;
+  bool on_receive_bytes(std::string& buffer) override;
 
   /**
-   * @copydoc ISocket::send_bytes(const std::string&)
+   * @copydoc ISocket::on_send_bytes(const std::string&)
    */
-  bool send_bytes(const std::string& buffer) override;
+  bool on_send_bytes(const std::string& buffer) override;
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/UDPServer.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/UDPServer.hpp
@@ -15,22 +15,22 @@ public:
    */
   UDPServer(UDPSocketConfiguration configuration);
 
-  /**
-   * @copydoc ISocket::open()
-   */
-  void open() override;
-
-  /**
-   * @copydoc ISocket::receive_bytes(std::string&)
-   */
-  bool receive_bytes(std::string& buffer) override;
-
-  /**
-   * @copydoc ISocket::send_bytes(const std::string&)
-   */
-  bool send_bytes(const std::string& buffer) override;
-
 private:
+  /**
+   * @copydoc ISocket::on_open()
+   */
+  void on_open() override;
+
+  /**
+   * @copydoc ISocket::on_receive_bytes(std::string&)
+   */
+  bool on_receive_bytes(std::string& buffer) override;
+
+  /**
+   * @copydoc ISocket::on_send_bytes(const std::string&)
+   */
+  bool on_send_bytes(const std::string& buffer) override;
+
   sockaddr_in client_address_;
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/UDPSocket.hpp
@@ -29,11 +29,6 @@ public:
    */
   ~UDPSocket() override;
 
-  /**
-   * @brief Close the socket
-   */
-  void close() override;
-
 protected:
   /**
    * @brief Constructor taking the configuration struct
@@ -62,6 +57,11 @@ protected:
    * @return True if bytes were sent, false otherwise
    */
   [[nodiscard]] bool sendto(const sockaddr_in& address, const std::string& buffer) const;
+
+  /**
+   * @copydoc ISocket::on_close()
+   */
+  void on_close() override;
 
   sockaddr_in server_address_; ///< Address of the UDP server
 

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisher.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisher.hpp
@@ -15,14 +15,15 @@ public:
    */
   explicit ZMQPublisher(ZMQSocketConfiguration configuration);
 
+private:
   /**
-   * @copydoc ISocket::open()
+   * @copydoc ISocket::on_open()
    */
-  void open() override;
+  void on_open() override;
 
   /**
    * @brief This method throws a runtime error as receiving is not available for a ZMQ publisher
    */
-  bool receive_bytes(std::string& buffer) override;
+  bool on_receive_bytes(std::string& buffer) override;
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisherSubscriber.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQPublisherSubscriber.hpp
@@ -36,32 +36,32 @@ public:
    */
   ~ZMQPublisherSubscriber() override;
 
+private:
   /**
    * @brief Open the internal ZMQ Publisher and Subscriber sockets for communication
    * @throws SocketConfigurationException if opening fails
    */
-  void open() override;
+  void on_open() override;
 
   /**
    * @brief Receive bytes from the internal ZMQ Subscriber socket
    * @param buffer The buffer to fill with the received bytes
    * @return True if bytes were received, false otherwise
    */
-  bool receive_bytes(std::string& buffer) override;
+  bool on_receive_bytes(std::string& buffer) override;
 
   /**
    * @brief Send bytes with the internal ZMQ Publisher socket
    * @param buffer The buffer with the bytes to send
    * @return True if bytes were sent, false otherwise
    */
-  bool send_bytes(const std::string& buffer) override;
+  bool on_send_bytes(const std::string& buffer) override;
 
   /**
-   * @brief Close the sockets
+   * @copydoc ISocket::on_close()
    */
-  void close() override;
+  void on_close() override;
 
-private:
   std::shared_ptr<ZMQPublisher> pub_; ///< ZMQ publisher
   std::shared_ptr<ZMQSubscriber> sub_; ///< ZMQ subscriber
 };

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSocket.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSocket.hpp
@@ -29,21 +29,6 @@ public:
    */
   ~ZMQSocket() override;
 
-  /**
-   * @brief Close the socket
-   */
-  void close() override;
-
-  /**
-   * @copydoc ISocket::receive_bytes(std::string&)
-   */
-  bool receive_bytes(std::string& buffer) override;
-
-  /**
-   * @copydoc ISocket::send_bytes(const std::string&)
-   */
-  bool send_bytes(const std::string& buffer) override;
-
 protected:
   /**
    * @brief Constructor taking the configuration struct
@@ -58,5 +43,21 @@ protected:
 
   ZMQSocketConfiguration config_; ///< Socket configuration struct
   std::shared_ptr<zmq::socket_t> socket_; ///< ZMQ socket
+
+private:
+  /**
+   * @copydoc ISocket::on_receive_bytes(std::string&)
+   */
+  bool on_receive_bytes(std::string& buffer) override;
+
+  /**
+   * @copydoc ISocket::on_send_bytes(const std::string&)
+   */
+  bool on_send_bytes(const std::string& buffer) override;
+
+  /**
+   * @copydoc ISocket::on_close()
+   */
+  void on_close() override;
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSubscriber.hpp
+++ b/source/communication_interfaces/include/communication_interfaces/sockets/ZMQSubscriber.hpp
@@ -16,13 +16,13 @@ public:
   explicit ZMQSubscriber(ZMQSocketConfiguration configuration);
 
   /**
-   * @copydoc ISocket::open()
+   * @copydoc ISocket::on_open()
    */
-  void open() override;
+  void on_open() override;
 
   /**
    * @brief This method throws a runtime error as sending is not available for a ZMQ publisher
    */
-  bool send_bytes(const std::string& buffer) override;
+  bool on_send_bytes(const std::string& buffer) override;
 };
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/src/sockets/ISocket.cpp
+++ b/source/communication_interfaces/src/sockets/ISocket.cpp
@@ -1,0 +1,30 @@
+#include "communication_interfaces/sockets/ISocket.hpp"
+
+#include "communication_interfaces/exceptions/SocketConfigurationException.hpp"
+
+namespace communication_interfaces::sockets {
+
+void ISocket::open() {
+  this->on_open();
+  this->opened_ = true;
+}
+
+bool ISocket::receive_bytes(std::string& buffer) {
+  if (!this->opened_) {
+    throw exceptions::SocketConfigurationException("Failed to received bytes: socket has not been opened yet");
+  }
+  return this->on_receive_bytes(buffer);
+}
+
+bool ISocket::send_bytes(const std::string& buffer) {
+  if (!this->opened_) {
+    throw exceptions::SocketConfigurationException("Failed to send bytes: socket has not been opened yet");
+  }
+  return this->on_send_bytes(buffer);
+}
+
+void ISocket::close() {
+  this->opened_ = false;
+  this->on_close();
+}
+}// namespace communication_interfaces::sockets

--- a/source/communication_interfaces/src/sockets/TCPClient.cpp
+++ b/source/communication_interfaces/src/sockets/TCPClient.cpp
@@ -8,7 +8,7 @@ namespace communication_interfaces::sockets {
 
 TCPClient::TCPClient(TCPClientConfiguration configuration) : TCPSocket(configuration.buffer_size), config_(configuration) {}
 
-void TCPClient::open() {
+void TCPClient::on_open() {
   try {
     bzero((char*) &this->server_address_, sizeof(this->server_address_));
     this->server_address_.sin_family = AF_INET;

--- a/source/communication_interfaces/src/sockets/TCPServer.cpp
+++ b/source/communication_interfaces/src/sockets/TCPServer.cpp
@@ -12,10 +12,10 @@ TCPServer::TCPServer(TCPServerConfiguration configuration) :
 }
 
 TCPServer::~TCPServer() {
-  TCPServer::close();
+  TCPServer::on_close();
 }
 
-void TCPServer::open() {
+void TCPServer::on_open() {
   try {
     bzero((char*) &this->server_address_, sizeof(this->server_address_));
     this->server_address_.sin_family = AF_INET;
@@ -51,8 +51,8 @@ void TCPServer::open() {
   }
 }
 
-void TCPServer::close() {
+void TCPServer::on_close() {
   ::close(this->server_fd_);
-  TCPSocket::close();
+  TCPSocket::on_close();
 }
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/src/sockets/TCPSocket.cpp
+++ b/source/communication_interfaces/src/sockets/TCPSocket.cpp
@@ -14,10 +14,10 @@ TCPSocket::TCPSocket(int buffer_size) : server_address_(), socket_fd_(), buffer_
 }
 
 TCPSocket::~TCPSocket() {
-  TCPSocket::close();
+  TCPSocket::on_close();
 }
 
-bool TCPSocket::receive_bytes(std::string& buffer) {
+bool TCPSocket::on_receive_bytes(std::string& buffer) {
   std::vector<char> local_buffer(this->buffer_size_);
   auto receive_length = recv(this->socket_fd_, local_buffer.data(), this->buffer_size_, 0);
   if (receive_length < 0) {
@@ -27,12 +27,12 @@ bool TCPSocket::receive_bytes(std::string& buffer) {
   return true;
 }
 
-bool TCPSocket::send_bytes(const std::string& buffer) {
+bool TCPSocket::on_send_bytes(const std::string& buffer) {
   int send_length = send(this->socket_fd_, buffer.data(), buffer.size(), 0);
   return send_length == static_cast<int>(buffer.size());
 }
 
-void TCPSocket::close() {
+void TCPSocket::on_close() {
   ::close(this->socket_fd_);
 }
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/src/sockets/UDPClient.cpp
+++ b/source/communication_interfaces/src/sockets/UDPClient.cpp
@@ -4,15 +4,15 @@ namespace communication_interfaces::sockets {
 
 UDPClient::UDPClient(UDPSocketConfiguration configuration) : UDPSocket(std::move(configuration)) {}
 
-void UDPClient::open() {
+void UDPClient::on_open() {
   this->open_socket(false);
 }
 
-bool UDPClient::receive_bytes(std::string& buffer) {
+bool UDPClient::on_receive_bytes(std::string& buffer) {
   return this->recvfrom(this->server_address_, buffer);
 }
 
-bool UDPClient::send_bytes(const std::string& buffer) {
+bool UDPClient::on_send_bytes(const std::string& buffer) {
   return this->sendto(this->server_address_, buffer);
 }
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/src/sockets/UDPServer.cpp
+++ b/source/communication_interfaces/src/sockets/UDPServer.cpp
@@ -4,15 +4,15 @@ namespace communication_interfaces::sockets {
 
 UDPServer::UDPServer(UDPSocketConfiguration configuration) : UDPSocket(std::move(configuration)) {}
 
-void UDPServer::open() {
+void UDPServer::on_open() {
   this->open_socket(true);
 }
 
-bool UDPServer::receive_bytes(std::string& buffer) {
+bool UDPServer::on_receive_bytes(std::string& buffer) {
   return this->recvfrom(this->client_address_, buffer);
 }
 
-bool UDPServer::send_bytes(const std::string& buffer) {
+bool UDPServer::on_send_bytes(const std::string& buffer) {
   return this->sendto(this->client_address_, buffer);
 }
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/src/sockets/UDPSocket.cpp
+++ b/source/communication_interfaces/src/sockets/UDPSocket.cpp
@@ -17,7 +17,7 @@ UDPSocket::UDPSocket(UDPSocketConfiguration configuration) :
 }
 
 UDPSocket::~UDPSocket() {
-  UDPSocket::close();
+  UDPSocket::on_close();
 }
 
 void UDPSocket::open_socket(bool bind_socket) {
@@ -75,7 +75,7 @@ bool UDPSocket::sendto(const sockaddr_in& address, const std::string& buffer) co
   return send_length == static_cast<int>(buffer.size());
 }
 
-void UDPSocket::close() {
+void UDPSocket::on_close() {
   if (this->server_fd_ >= 0) {
     ::close(this->server_fd_);
     this->server_fd_ = -1;

--- a/source/communication_interfaces/src/sockets/ZMQPublisher.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQPublisher.cpp
@@ -4,12 +4,12 @@ namespace communication_interfaces::sockets {
 
 ZMQPublisher::ZMQPublisher(ZMQSocketConfiguration configuration) : ZMQSocket(std::move(configuration)) {}
 
-void ZMQPublisher::open() {
+void ZMQPublisher::on_open() {
   this->socket_ = std::make_shared<zmq::socket_t>(*this->config_.context, ZMQ_PUB);
   this->open_socket();
 }
 
-bool ZMQPublisher::receive_bytes(std::string&) {
+bool ZMQPublisher::on_receive_bytes(std::string&) {
   throw std::runtime_error("Receive not available for socket of type ZMQPublisher");
 }
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/src/sockets/ZMQPublisherSubscriber.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQPublisherSubscriber.cpp
@@ -21,20 +21,20 @@ ZMQPublisherSubscriber::~ZMQPublisherSubscriber() {
   ZMQPublisherSubscriber::close();
 }
 
-void ZMQPublisherSubscriber::open() {
+void ZMQPublisherSubscriber::on_open() {
   this->pub_->open();
   this->sub_->open();
 }
 
-bool ZMQPublisherSubscriber::receive_bytes(std::string& buffer) {
+bool ZMQPublisherSubscriber::on_receive_bytes(std::string& buffer) {
   return this->sub_->receive_bytes(buffer);
 }
 
-bool ZMQPublisherSubscriber::send_bytes(const std::string& buffer) {
+bool ZMQPublisherSubscriber::on_send_bytes(const std::string& buffer) {
   return this->pub_->send_bytes(buffer);
 }
 
-void ZMQPublisherSubscriber::close() {
+void ZMQPublisherSubscriber::on_close() {
   this->pub_->close();
   this->sub_->close();
 }

--- a/source/communication_interfaces/src/sockets/ZMQSocket.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQSocket.cpp
@@ -7,7 +7,7 @@ namespace communication_interfaces::sockets {
 ZMQSocket::ZMQSocket(ZMQSocketConfiguration configuration) : config_(std::move(configuration)) {}
 
 ZMQSocket::~ZMQSocket() {
-  ZMQSocket::close();
+  ZMQSocket::on_close();
 }
 
 void ZMQSocket::open_socket() {
@@ -23,7 +23,7 @@ void ZMQSocket::open_socket() {
   }
 }
 
-bool ZMQSocket::receive_bytes(std::string& buffer) {
+bool ZMQSocket::on_receive_bytes(std::string& buffer) {
   zmq::recv_flags recv_flag = this->config_.wait ? zmq::recv_flags::none : zmq::recv_flags::dontwait;
   zmq::message_t message;
   try {
@@ -37,7 +37,7 @@ bool ZMQSocket::receive_bytes(std::string& buffer) {
   }
 }
 
-bool ZMQSocket::send_bytes(const std::string& buffer) {
+bool ZMQSocket::on_send_bytes(const std::string& buffer) {
   zmq::send_flags send_flags = this->config_.wait ? zmq::send_flags::none : zmq::send_flags::dontwait;
   zmq::message_t msg(buffer.size());
   memcpy(msg.data(), buffer.data(), buffer.size());
@@ -52,7 +52,7 @@ bool ZMQSocket::send_bytes(const std::string& buffer) {
   }
 }
 
-void ZMQSocket::close() {
+void ZMQSocket::on_close() {
   if (this->socket_ != nullptr && this->socket_->connected()) {
     this->socket_->close();
   }

--- a/source/communication_interfaces/src/sockets/ZMQSubscriber.cpp
+++ b/source/communication_interfaces/src/sockets/ZMQSubscriber.cpp
@@ -4,14 +4,14 @@ namespace communication_interfaces::sockets {
 
 ZMQSubscriber::ZMQSubscriber(ZMQSocketConfiguration configuration) : ZMQSocket(std::move(configuration)) {}
 
-void ZMQSubscriber::open() {
+void ZMQSubscriber::on_open() {
   this->socket_ = std::make_shared<zmq::socket_t>(*this->config_.context, ZMQ_SUB);
   this->socket_->set(zmq::sockopt::conflate, 1);
   this->socket_->set(zmq::sockopt::subscribe, "");
   this->open_socket();
 }
 
-bool ZMQSubscriber::send_bytes(const std::string&) {
+bool ZMQSubscriber::on_send_bytes(const std::string&) {
   throw std::runtime_error("Send not available for socket of type ZMQSubscriber");
 }
 } // namespace communication_interfaces::sockets

--- a/source/communication_interfaces/test/tests/test_tcp_communication.cpp
+++ b/source/communication_interfaces/test/tests/test_tcp_communication.cpp
@@ -51,4 +51,22 @@ TEST_F(TestTCPSockets, TestCommunication) {
 
   client.join();
   server.join();
+
+  std::string buffer;
+  this->server_->close();
+  EXPECT_THROW(this->server_->receive_bytes(buffer), exceptions::SocketConfigurationException);
+  EXPECT_THROW(this->server_->send_bytes(buffer), exceptions::SocketConfigurationException);
+  this->client_->close();
+  EXPECT_THROW(this->client_->receive_bytes(buffer), exceptions::SocketConfigurationException);
+  EXPECT_THROW(this->client_->send_bytes(buffer), exceptions::SocketConfigurationException);
+}
+
+TEST_F(TestTCPSockets, TestNotOpen) {
+  std::string buffer;
+  
+  EXPECT_THROW(this->server_->receive_bytes(buffer), exceptions::SocketConfigurationException);
+  EXPECT_THROW(this->server_->send_bytes(buffer), exceptions::SocketConfigurationException);
+  
+  EXPECT_THROW(this->client_->receive_bytes(buffer), exceptions::SocketConfigurationException);
+  EXPECT_THROW(this->client_->send_bytes(buffer), exceptions::SocketConfigurationException);
 }

--- a/source/communication_interfaces/test/tests/test_udp_communication.cpp
+++ b/source/communication_interfaces/test/tests/test_udp_communication.cpp
@@ -67,7 +67,7 @@ TEST_F(TestUDPSockets, OpenClose) {
   EXPECT_THROW(server.receive_bytes(buffer), exceptions::SocketConfigurationException);
   server.open();
 
-  EXPECT_TRUE(server.send_bytes(std::string("test")));
+  EXPECT_FALSE(server.send_bytes(std::string("test")));
   EXPECT_FALSE(server.receive_bytes(buffer));
   // Close server socket
   server.close();

--- a/source/communication_interfaces/test/tests/test_zmq_communication.cpp
+++ b/source/communication_interfaces/test/tests/test_zmq_communication.cpp
@@ -68,3 +68,15 @@ TEST_F(TestZMQSockets, SendReceiveCombined) {
   server.close();
   client.close();
 }
+
+TEST_F(TestZMQSockets, TestOpenClose) {
+  std::string buffer;
+  sockets::ZMQPublisher socket(this->config_);
+  EXPECT_THROW(socket.send_bytes(buffer), exceptions::SocketConfigurationException);
+  EXPECT_THROW(socket.receive_bytes(buffer), std::runtime_error);
+
+  socket.open();
+  EXPECT_TRUE(socket.send_bytes(std::string("test")));
+  socket.close();
+  EXPECT_THROW(socket.send_bytes(buffer), exceptions::SocketConfigurationException);
+}


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #65 

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by applying to proposed change in the parent topic to the base class, with one difference: the receive/send function throw an exception if the socket hasn't been opened. Otherwise it might be really hard to understand if it failed because there is no connection or because it was not opened.

Quite a big PR because this required changes in all derived socket classes and I updated the tests quite a bit.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 15 minutes
Review by commit possible

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->